### PR TITLE
Fix print window delay

### DIFF
--- a/src/components/PlaybookLibrary.jsx
+++ b/src/components/PlaybookLibrary.jsx
@@ -186,19 +186,9 @@ const PlaybookLibrary = () => {
       }
     }
 
-      const finalizePrint = () => {
-        w.focus();
-        w.print();
-        w.close();
-      };
-
-      // Attach the load listener before writing in case the event fires
-      // quickly after document.close(). Delay printing slightly to ensure
-      // styles are applied.
-      w.addEventListener('load', () => setTimeout(finalizePrint, 100));
-
       w.document.write('</body></html>');
       w.document.close();
+      setTimeout(() => { w.focus(); w.print(); w.close(); }, 300);
 
     setPrintBookId(null);
   };


### PR DESCRIPTION
## Summary
- ensure playbook printing waits for render by delaying after document close

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841e2d893dc8324ac86b1aa29a00a2a