### PR TITLE
Adjust route thickness defaults

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -207,7 +207,7 @@ const PlayEditor = ({ loadedPlay }) => {
         return;
       }
 
-      const originals = routes.map(r => r.thickness || 3);
+      const originals = routes.map(r => r.thickness || 7);
 
       if (thicknessMultiplier !== 1) {
         routes.forEach((route, idx) => {
@@ -448,13 +448,13 @@ const PlayEditor = ({ loadedPlay }) => {
 
                 <label className="block mt-2 mb-1">Line Thickness</label>
                 <select
-                  value={routes[selectedRouteIndex].thickness || 3}
+                  value={routes[selectedRouteIndex].thickness || 7}
                   onChange={(e) => updateRouteProperty('thickness', parseInt(e.target.value, 10))}
                   className="w-full p-1 rounded text-white bg-gray-700"
                 >
-                  <option value={2}>Thin</option>
-                  <option value={3}>Default</option>
-                  <option value={5}>Thick</option>
+                  <option value={5}>Thin</option>
+                  <option value={7}>Default</option>
+                  <option value={9}>Thick</option>
                 </select>
 
                 <label className="block mt-2 mb-1">End Marker</label>

--- a/src/components/FootballField.jsx
+++ b/src/components/FootballField.jsx
@@ -159,7 +159,7 @@ const FootballField = ({
           endMarker: 'arrow',
           showLastSegment: true,
           finished: false,
-          thickness: 3
+          thickness: 7
         });
       }
 
@@ -221,7 +221,7 @@ const FootballField = ({
                 <Path
                   data={d3Path}
                   stroke={color}
-                  strokeWidth={thickness || 3}
+                  strokeWidth={thickness || 7}
                   dash={style === 'dashed' ? [10, 10] : []}
                   hitStrokeWidth={20}
                   onClick={(e) => handleRouteClick(e, index)}
@@ -243,7 +243,7 @@ const FootballField = ({
                     fill={color}
                     pointerLength={10}
                     pointerWidth={10}
-                    strokeWidth={thickness || 3}
+                    strokeWidth={thickness || 7}
                   />
                 )
               )}


### PR DESCRIPTION
## Summary
- bump default route thickness values
- adjust drawing routines and route creation logic

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841e34ff42c8324bcc15d57b64d409c