### PR TITLE
Fix label colors in print preview

### DIFF
--- a/src/components/PlaybookLibrary.jsx
+++ b/src/components/PlaybookLibrary.jsx
@@ -143,8 +143,8 @@ const PlaybookLibrary = () => {
                 .grid{display:grid;${isWrist ? `grid-template-columns:repeat(${columns}, ${cellWidth}in);grid-template-rows:repeat(2, ${cellHeight}in);width:${gridWidth}in;height:${gridHeight}in;margin:auto;gap:0;` : 'grid-template-columns:repeat(4,1fr);gap:4px;'}}
         .play{position:relative;border:1px solid #000;${isWrist ? `width:${cellWidth}in;height:${cellHeight}in;` : 'padding:2px;'}text-align:center;}
         .label{position:absolute;top:0;left:0;display:flex;width:100%;z-index:1;}
-                .num{background:#fff;color:#000;padding:2px 4px;font-size:10px;display:flex;justify-content:center;align-items:center;}
-        .title{background:#000;color:#fff;padding:2px 4px;font-size:10px;flex:1;display:flex;align-items:center;}
+                .num{background:#000;color:#fff;padding:2px 4px;font-size:10px;display:flex;justify-content:center;align-items:center;}
+        .title{background:#eee;color:#000;padding:2px 4px;font-size:10px;flex:1;display:flex;align-items:center;}
         img{width:100%;height:100%;object-fit:contain;display:block;image-rendering:pixelated;}
       </style>
     `;


### PR DESCRIPTION
## Summary
- adjust styling in `handlePrintConfirm` so numeric badges are white on black and titles are black on light grey

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841e76753248324bb9bbbe52450bd94