### PR TITLE
Implement drag handling for route points

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -201,6 +201,19 @@ const PlayEditor = ({ loadedPlay }) => {
     }
   };
 
+  const handlePointDrag = (routeIdx, pointIdx, x, y) => {
+    setRoutes(prevRoutes => {
+      const newRoutes = [...prevRoutes];
+      const route = { ...newRoutes[routeIdx] };
+      const points = [...route.points];
+      points[pointIdx * 2] = x;
+      points[pointIdx * 2 + 1] = y;
+      route.points = points;
+      newRoutes[routeIdx] = route;
+      return newRoutes;
+    });
+  };
+
   const getExportDataUrl = async (ratio, thicknessMultiplier = 1) => {
     return new Promise(resolve => {
       if (!stageRef.current) {
@@ -396,6 +409,7 @@ const PlayEditor = ({ loadedPlay }) => {
           setSelectedRouteIndex={setSelectedRouteIndex}
           selectedNoteIndex={selectedNoteIndex}
           setSelectedNoteIndex={setSelectedNoteIndex}
+          handlePointDrag={handlePointDrag}
           stageRef={stageRef}
         />
 


### PR DESCRIPTION
## Summary
- update PlayEditor with `handlePointDrag` helper
- pass drag handler to `FootballField`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841e76cd68c8324bf872f1bab9416b7