### PR TITLE
Add sign-in modal and controls

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,10 +3,11 @@ import { BrowserRouter as Router, Routes, Route, Link, useNavigate } from 'react
 import PlayEditor from './PlayEditor';
 import PlayLibrary from './components/PlayLibrary';
 import PlaybookLibrary from './components/PlaybookLibrary';
+import SignInModal from './components/SignInModal';
 import logo from './assets/huddlup_logo_2.svg';
 import { Home, Book, BookOpen } from 'lucide-react';
 
-const AppContent = () => {
+const AppContent = ({ openSignIn, isAuthenticated, onSignOut }) => {
   const [selectedPlay, setSelectedPlay] = useState(null);
   const navigate = useNavigate();
 
@@ -24,33 +25,53 @@ const AppContent = () => {
             <img src={logo} alt="HuddlUp Logo" className="h-8" />
             <h1 className="text-xl font-bold">huddlup</h1>
           </div>
-          <nav className="flex flex-wrap gap-2">
-            <Link
-              to="/"
-              className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
-            >
-              <Home className="w-4 h-4 mr-1" /> Editor
-            </Link>
-            <Link
-              to="/library"
-              className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
-            >
-              <Book className="w-4 h-4 mr-1" /> Play Library
-            </Link>
-            <Link
-              to="/playbooks"
-              className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
-            >
-              <BookOpen className="w-4 h-4 mr-1" /> Playbooks
-            </Link>
-          </nav>
+          <div className="flex items-center gap-2">
+            <nav className="flex flex-wrap gap-2">
+              <Link
+                to="/"
+                className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+              >
+                <Home className="w-4 h-4 mr-1" /> Editor
+              </Link>
+              <Link
+                to="/library"
+                className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+              >
+                <Book className="w-4 h-4 mr-1" /> Play Library
+              </Link>
+              <Link
+                to="/playbooks"
+                className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+              >
+                <BookOpen className="w-4 h-4 mr-1" /> Playbooks
+              </Link>
+            </nav>
+            {isAuthenticated ? (
+              <button
+                onClick={onSignOut}
+                className="bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+              >
+                Sign Out
+              </button>
+            ) : (
+              <button
+                onClick={openSignIn}
+                className="bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+              >
+                Sign In
+              </button>
+            )}
+          </div>
         </div>
       </header>
 
       {/* Main Content */}
       <main className="flex-grow">
         <Routes>
-          <Route path="/" element={<PlayEditor loadedPlay={selectedPlay} />} />
+          <Route
+            path="/"
+            element={<PlayEditor loadedPlay={selectedPlay} openSignIn={openSignIn} />}
+          />
           <Route path="/library" element={<PlayLibrary onSelectPlay={handleLoadPlay} />} />
           <Route path="/playbooks" element={<PlaybookLibrary />} />
         </Routes>
@@ -60,9 +81,31 @@ const AppContent = () => {
 };
 
 const App = () => {
+  const [showSignIn, setShowSignIn] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  const openSignIn = () => setShowSignIn(true);
+  const closeSignIn = () => setShowSignIn(false);
+
+  const handleSignIn = () => {
+    setIsAuthenticated(true);
+    closeSignIn();
+  };
+
+  const handleSignOut = () => {
+    setIsAuthenticated(false);
+  };
+
   return (
     <Router>
-      <AppContent />
+      <AppContent
+        openSignIn={openSignIn}
+        isAuthenticated={isAuthenticated}
+        onSignOut={handleSignOut}
+      />
+      {showSignIn && (
+        <SignInModal onClose={closeSignIn} onSignIn={handleSignIn} />
+      )}
     </Router>
   );
 };

--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -26,7 +26,7 @@ const colorOptions = [
 const shapeOptions = ['circle', 'square', 'oval', 'star'];
 const endMarkerOptions = ['arrow', 'dot', 'T'];
 
-const PlayEditor = ({ loadedPlay }) => {
+const PlayEditor = ({ loadedPlay, openSignIn }) => {
   const [players, setPlayers] = useState(initialPlayersTemplate);
   const [routes, setRoutes] = useState([]);
   const [notes, setNotes] = useState([]);

--- a/src/components/SignInModal.jsx
+++ b/src/components/SignInModal.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const SignInModal = ({ onClose, onSignIn }) => (
+  <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+    <div className="bg-white text-black rounded p-4 w-80">
+      <h2 className="text-lg font-bold mb-2">Sign In</h2>
+      <p className="mb-4">Sign in to continue.</p>
+      <div className="flex justify-end gap-2">
+        <button onClick={onClose} className="px-3 py-1 rounded bg-gray-300">
+          Cancel
+        </button>
+        <button onClick={onSignIn} className="px-3 py-1 rounded bg-blue-600 text-white">
+          Sign In
+        </button>
+      </div>
+    </div>
+  </div>
+);
+
+export default SignInModal;


### PR DESCRIPTION
## Summary
- build a basic SignInModal component
- wire App to handle sign-in modal and auth state
- forward an `openSignIn` prop through AppContent to PlayEditor
- show Sign In/Sign Out button in App header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841fa964dac832482156d375f253a02