### PR TITLE
Implement authentication check when saving plays

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,10 @@ const AppContent = () => {
   const [selectedPlay, setSelectedPlay] = useState(null);
   const navigate = useNavigate();
 
+  const handleSignInRequest = () => {
+    alert('Please sign in to save plays.');
+  };
+
   const handleLoadPlay = (play) => {
     setSelectedPlay(play);
     navigate('/');  // Use navigate to stay within SPA and preserve state
@@ -50,7 +54,15 @@ const AppContent = () => {
       {/* Main Content */}
       <main className="flex-grow">
         <Routes>
-          <Route path="/" element={<PlayEditor loadedPlay={selectedPlay} />} />
+          <Route
+            path="/"
+            element={
+              <PlayEditor
+                loadedPlay={selectedPlay}
+                onSignInRequest={handleSignInRequest}
+              />
+            }
+          />
           <Route path="/library" element={<PlayLibrary onSelectPlay={handleLoadPlay} />} />
           <Route path="/playbooks" element={<PlaybookLibrary />} />
         </Routes>

--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -3,6 +3,8 @@ import FootballField from './components/FootballField';
 import Toolbar from './components/Toolbar';
 import { User, ArrowRight, Trash2, StickyNote } from 'lucide-react';
 import huddlupLogo from './assets/huddlup_logo_2.svg';
+import { doc, setDoc } from 'firebase/firestore';
+import { auth, db } from './firebase';
 
 const width = 800;
 const height = 600;
@@ -26,7 +28,7 @@ const colorOptions = [
 const shapeOptions = ['circle', 'square', 'oval', 'star'];
 const endMarkerOptions = ['arrow', 'dot', 'T'];
 
-const PlayEditor = ({ loadedPlay }) => {
+const PlayEditor = ({ loadedPlay, onSignInRequest }) => {
   const [players, setPlayers] = useState(initialPlayersTemplate);
   const [routes, setRoutes] = useState([]);
   const [notes, setNotes] = useState([]);
@@ -82,6 +84,11 @@ const PlayEditor = ({ loadedPlay }) => {
       return;
     }
 
+    if (!auth.currentUser) {
+      onSignInRequest && onSignInRequest();
+      return;
+    }
+
     const dataURL = await getExportDataUrl(4 / 3);
 
     const playKey = `Play-${Date.now()}`;
@@ -98,7 +105,7 @@ const PlayEditor = ({ loadedPlay }) => {
       image: dataURL
     };
 
-    localStorage.setItem(playKey, JSON.stringify(playData));
+    await setDoc(doc(db, 'plays', playKey), playData);
     setShowSaveModal(true);
 
     setSavedState({

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,0 +1,15 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_AUTH_DOMAIN',
+  projectId: 'YOUR_PROJECT_ID',
+};
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+const db = getFirestore(app);
+
+export { auth, db };


### PR DESCRIPTION
## Summary
- add Firebase configuration stub for auth and Firestore
- update `PlayEditor` to save plays to Firestore only when signed in
- call sign‑in request callback when saving without authentication
- pass `onSignInRequest` from `App` to `PlayEditor`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841faa103cc83248bd55bed64b2ab19