### PR TITLE
Check auth before saving

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -84,6 +84,11 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
       return;
     }
 
+    if (!auth.currentUser) {
+      openSignIn();
+      return;
+    }
+
     const dataURL = await getExportDataUrl(4 / 3);
 
     const playKey = `Play-${Date.now()}`;
@@ -100,11 +105,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
       image: dataURL
     };
 
-    if (auth.currentUser) {
-      await setDoc(doc(db, 'users', auth.currentUser.uid, 'plays', playKey), playData);
-    } else {
-      localStorage.setItem(playKey, JSON.stringify(playData));
-    }
+    await setDoc(doc(db, 'users', auth.currentUser.uid, 'plays', playKey), playData);
     setShowSaveModal(true);
 
     setSavedState({


### PR DESCRIPTION
## Summary
- prompt a sign in when saving a play without being logged in

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6842101ee5f08324ba9b48803d507798