### PR TITLE
Adjust authentication UI logic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link, useNavigate } from 'react-router-dom';
 import { onAuthStateChanged, signOut } from 'firebase/auth';
 import { auth } from './firebase';
-import SignIn from './components/SignIn';
 import PlayEditor from './PlayEditor';
 import PlayLibrary from './components/PlayLibrary';
 import PlaybookLibrary from './components/PlaybookLibrary';
@@ -48,13 +47,24 @@ const AppContent = ({ user, openSignIn }) => {
             >
               <BookOpen className="w-4 h-4 mr-1" /> Playbooks
             </Link>
-            <span className="mx-2 text-sm">{user.email}</span>
-            <button
-              onClick={() => signOut(auth)}
-              className="bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
-            >
-              Sign Out
-            </button>
+            {user ? (
+              <>
+                <span className="mx-2 text-sm">{user.email}</span>
+                <button
+                  onClick={() => signOut(auth)}
+                  className="bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+                >
+                  Sign Out
+                </button>
+              </>
+            ) : (
+              <button
+                onClick={openSignIn}
+                className="bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+              >
+                Sign In
+              </button>
+            )}
             </nav>
 
         </div>
@@ -86,10 +96,6 @@ const App = () => {
     const unsub = onAuthStateChanged(auth, setUser);
     return unsub;
   }, []);
-
-  if (!user) {
-    return <SignIn />;
-  }
 
   return (
     <Router>


### PR DESCRIPTION
## Summary
- remove unused SignIn import and early return
- show Sign In button in header when no user
- keep Sign Out when user present

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684210d0b8a48324ab229cfc2189e40e