### PR TITLE
Add stateful auth to SignInModal

### DIFF
--- a/src/components/SignInModal.jsx
+++ b/src/components/SignInModal.jsx
@@ -1,8 +1,33 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { auth } from '../firebase';
+import {
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+} from 'firebase/auth';
 import { X } from 'lucide-react';
 import logo from '../assets/huddlup_logo_2.svg';
 
 const SignInModal = ({ onClose }) => {
+  const [isRegister, setIsRegister] = useState(false);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      if (isRegister) {
+        await createUserWithEmailAndPassword(auth, email, password);
+      } else {
+        await signInWithEmailAndPassword(auth, email, password);
+      }
+      onClose();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div className="relative bg-gray-800 text-white rounded p-6 w-80">
@@ -15,24 +40,37 @@ const SignInModal = ({ onClose }) => {
         <div className="text-center mb-4">
           <img src={logo} alt="HuddlUp Logo" className="h-10 mx-auto" />
         </div>
-        <form className="flex flex-col gap-2">
+        {error && <p className="text-red-500 text-sm mb-2">{error}</p>}
+        <form onSubmit={handleSubmit} className="flex flex-col gap-2">
           <input
             type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
             placeholder="Email"
             className="p-2 rounded bg-gray-700 text-white"
+            required
           />
           <input
             type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
             placeholder="Password"
             className="p-2 rounded bg-gray-700 text-white"
+            required
           />
           <button
             type="submit"
             className="mt-2 px-3 py-1 rounded bg-blue-600 hover:bg-blue-500"
           >
-            Sign In
+            {isRegister ? 'Create Account' : 'Sign In'}
           </button>
         </form>
+        <button
+          onClick={() => setIsRegister(!isRegister)}
+          className="text-sm text-blue-300 mt-2"
+        >
+          {isRegister ? 'Already have an account?' : 'Need an account?'}
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- connect SignInModal to Firebase auth
- add state hooks for email/password/register toggle
- display auth errors
- close modal on successful auth

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684210da75cc8324adf096e65b5fd44b