### PR TITLE
Prompt sign in for library pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -67,8 +67,20 @@ const AppContent = ({ user, openSignIn }) => {
             path="/"
             element={<PlayEditor loadedPlay={selectedPlay} openSignIn={openSignIn} />}
           />
-          <Route path="/library" element={<PlayLibrary onSelectPlay={handleLoadPlay} />} />
-          <Route path="/playbooks" element={<PlaybookLibrary />} />
+          <Route
+            path="/library"
+            element={
+              <PlayLibrary
+                onSelectPlay={handleLoadPlay}
+                user={user}
+                openSignIn={openSignIn}
+              />
+            }
+          />
+          <Route
+            path="/playbooks"
+            element={<PlaybookLibrary user={user} openSignIn={openSignIn} />}
+          />
         </Routes>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- open sign-in modal in `PlayLibrary` and `PlaybookLibrary` when user not authenticated
- display message prompting user to sign in
- pass `user` and `openSignIn` from `AppContent` to these pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684210de5b308324a82851df2e60cddc