### PR TITLE
Add Save As button in PlayEditor

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { auth, db } from './firebase';
-import { doc, setDoc } from 'firebase/firestore';
-import FootballField from './components/FootballField';
-import Toolbar from './components/Toolbar';
-import { User, ArrowRight, Trash2, StickyNote } from 'lucide-react';
-import huddlupLogo from './assets/huddlup_logo_2.svg';
+import React, { useState, useEffect, useRef } from "react";
+import { auth, db } from "./firebase";
+import { doc, setDoc } from "firebase/firestore";
+import FootballField from "./components/FootballField";
+import Toolbar from "./components/Toolbar";
+import { User, ArrowRight, Trash2, StickyNote } from "lucide-react";
+import huddlupLogo from "./assets/huddlup_logo_2.svg";
 
 const width = 800;
 const height = 600;
@@ -12,21 +12,68 @@ const centerX = width / 2;
 const lineOfScrimmageY = height - 250;
 
 const initialPlayersTemplate = [
-  { id: 'C', x: centerX, y: lineOfScrimmageY, shape: 'square', fill: '#374151', textColor: 'white', border: false },
-  { id: 'Y', x: 100, y: lineOfScrimmageY, shape: 'circle', fill: '#3B82F6', textColor: 'white', border: false },
-  { id: 'Z', x: centerX + 100, y: lineOfScrimmageY, shape: 'circle', fill: '#10B981', textColor: 'white', border: false },
-  { id: 'X', x: width - 100, y: lineOfScrimmageY, shape: 'circle', fill: '#F97316', textColor: 'black', border: false },
-  { id: 'Q', x: centerX, y: lineOfScrimmageY + 75, shape: 'circle', fill: '#EF4444', textColor: 'white', border: false }
+  {
+    id: "C",
+    x: centerX,
+    y: lineOfScrimmageY,
+    shape: "square",
+    fill: "#374151",
+    textColor: "white",
+    border: false,
+  },
+  {
+    id: "Y",
+    x: 100,
+    y: lineOfScrimmageY,
+    shape: "circle",
+    fill: "#3B82F6",
+    textColor: "white",
+    border: false,
+  },
+  {
+    id: "Z",
+    x: centerX + 100,
+    y: lineOfScrimmageY,
+    shape: "circle",
+    fill: "#10B981",
+    textColor: "white",
+    border: false,
+  },
+  {
+    id: "X",
+    x: width - 100,
+    y: lineOfScrimmageY,
+    shape: "circle",
+    fill: "#F97316",
+    textColor: "black",
+    border: false,
+  },
+  {
+    id: "Q",
+    x: centerX,
+    y: lineOfScrimmageY + 75,
+    shape: "circle",
+    fill: "#EF4444",
+    textColor: "white",
+    border: false,
+  },
 ];
 
 const colorOptions = [
-  '#1E40AF', '#93C5FD', '#065F46', '#6EE7B7',
-  '#C2410C', '#FDBA74', '#991B1B', '#FCA5A5',
-  '#111827', '#9CA3AF'
+  "#1E40AF",
+  "#93C5FD",
+  "#065F46",
+  "#6EE7B7",
+  "#C2410C",
+  "#FDBA74",
+  "#991B1B",
+  "#FCA5A5",
+  "#111827",
+  "#9CA3AF",
 ];
 
-const shapeOptions = ['circle', 'square', 'oval', 'star'];
-const endMarkerOptions = ['arrow', 'dot', 'T'];
+const shapeOptions = ["circle", "square", "oval", "star"];
+const endMarkerOptions = ["arrow", "dot", "T"];
 
 const PlayEditor = ({ loadedPlay, openSignIn }) => {
   const [players, setPlayers] = useState(initialPlayersTemplate);
@@ -36,14 +83,16 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
   const [selectedPlayerIndex, setSelectedPlayerIndex] = useState(null);
   const [selectedRouteIndex, setSelectedRouteIndex] = useState(null);
   const [selectedNoteIndex, setSelectedNoteIndex] = useState(null);
-  const [playName, setPlayName] = useState('');
-  const [playTags, setPlayTags] = useState('');
+  const [playName, setPlayName] = useState("");
+  const [playTags, setPlayTags] = useState("");
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [savedState, setSavedState] = useState(null);
   const stageRef = useRef(null);
 
   useEffect(() => {
-    setUndoStack([{ players: [...initialPlayersTemplate], routes: [], notes: [] }]);
+    setUndoStack([
+      { players: [...initialPlayersTemplate], routes: [], notes: [] },
+    ]);
   }, []);
 
   // New: Load the play if loadedPlay exists
@@ -52,35 +101,35 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
       setPlayers(loadedPlay.players || initialPlayersTemplate);
       setRoutes(loadedPlay.routes || []);
       setNotes(loadedPlay.notes || []);
-      setPlayName(loadedPlay.name || '');
-      setPlayTags((loadedPlay.tags || []).join(', '));
+      setPlayName(loadedPlay.name || "");
+      setPlayTags((loadedPlay.tags || []).join(", "));
       setSavedState({
         players: loadedPlay.players || [],
         routes: loadedPlay.routes || [],
         notes: loadedPlay.notes || [],
-        name: loadedPlay.name || '',
-        tags: loadedPlay.tags || []
+        name: loadedPlay.name || "",
+        tags: loadedPlay.tags || [],
       });
     }
   }, [loadedPlay]);
 
   const handleNewPlay = () => {
-    setUndoStack(prev => [
+    setUndoStack((prev) => [
       ...prev,
-      { players: [...players], routes: [...routes], notes: [...notes] }
+      { players: [...players], routes: [...routes], notes: [...notes] },
     ]);
     setPlayers(initialPlayersTemplate);
     setSelectedPlayerIndex(null);
     setRoutes([]);
     setNotes([]);
-    setPlayName('');
-    setPlayTags('');
+    setPlayName("");
+    setPlayTags("");
     setSavedState(null);
   };
 
   const handleSave = async () => {
     if (!playName.trim()) {
-      alert('Please provide a name for your play.');
+      alert("Please provide a name for your play.");
       return;
     }
 
@@ -99,13 +148,16 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
       notes,
       name: playName,
       tags: playTags
-        .split(',')
-        .map(tag => tag.trim())
-        .filter(tag => tag !== ''),
-      image: dataURL
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter((tag) => tag !== ""),
+      image: dataURL,
     };
 
-    await setDoc(doc(db, 'users', auth.currentUser.uid, 'plays', playKey), playData);
+    await setDoc(
+      doc(db, "users", auth.currentUser.uid, "plays", playKey),
+      playData,
+    );
     setShowSaveModal(true);
 
     setSavedState({
@@ -114,15 +166,70 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
       notes,
       name: playName,
       tags: playTags
-        .split(',')
-        .map(tag => tag.trim())
-        .filter(tag => tag !== '')
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter((tag) => tag !== ""),
     });
+  };
+
+  const handleSaveAs = async () => {
+    if (!auth.currentUser) {
+      openSignIn();
+      return;
+    }
+
+    let newName = prompt("Enter a name for the new play:", playName);
+    if (newName !== null) {
+      newName = newName.trim();
+      if (newName) {
+        setPlayName(newName);
+      } else {
+        newName = playName;
+      }
+    } else {
+      newName = playName;
+    }
+
+    const dataURL = await getExportDataUrl(4 / 3);
+    const playKey = `Play-${Date.now()}`;
+    const playData = {
+      id: playKey,
+      players,
+      routes,
+      notes,
+      name: newName,
+      tags: playTags
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter((tag) => tag !== ""),
+      image: dataURL,
+    };
+
+    await setDoc(
+      doc(db, "users", auth.currentUser.uid, "plays", playKey),
+      playData,
+    );
+    setShowSaveModal(true);
+
+    setSavedState(
+      JSON.parse(
+        JSON.stringify({
+          players,
+          routes,
+          notes,
+          name: newName,
+          tags: playTags
+            .split(",")
+            .map((tag) => tag.trim())
+            .filter((tag) => tag !== ""),
+        }),
+      ),
+    );
   };
 
   const handleUndo = () => {
     if (undoStack.length > 1) {
-      setUndoStack(prevStack => {
+      setUndoStack((prevStack) => {
         const newStack = [...prevStack];
         newStack.pop();
         const prevState = newStack[newStack.length - 1];
@@ -139,9 +246,9 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
 
   const handleDeleteRoute = () => {
     if (selectedRouteIndex !== null) {
-      setUndoStack(prev => [
+      setUndoStack((prev) => [
         ...prev,
-        { players: [...players], routes: [...routes], notes: [...notes] }
+        { players: [...players], routes: [...routes], notes: [...notes] },
       ]);
       const updatedRoutes = [...routes];
       updatedRoutes.splice(selectedRouteIndex, 1);
@@ -154,16 +261,16 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
     const newNote = {
       x: 100,
       y: 100,
-      text: 'New Note',
+      text: "New Note",
       fontSize: 16,
-      fontColor: '#000000',
+      fontColor: "#000000",
       bold: false,
-      backgroundColor: '#FFFFFF',
-      border: false
+      backgroundColor: "#FFFFFF",
+      border: false,
     };
-    setUndoStack(prev => [
+    setUndoStack((prev) => [
       ...prev,
-      { players: [...players], routes: [...routes], notes: [...notes] }
+      { players: [...players], routes: [...routes], notes: [...notes] },
     ]);
     setNotes([...notes, newNote]);
   };
@@ -188,7 +295,8 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
 
   const handleBorderToggle = () => {
     const updatedPlayers = [...players];
-    updatedPlayers[selectedPlayerIndex].border = !updatedPlayers[selectedPlayerIndex].border;
+    updatedPlayers[selectedPlayerIndex].border =
+      !updatedPlayers[selectedPlayerIndex].border;
     setPlayers(updatedPlayers);
   };
 
@@ -209,7 +317,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
   };
 
   const handlePointDrag = (routeIdx, pointIdx, x, y) => {
-    setRoutes(prevRoutes => {
+    setRoutes((prevRoutes) => {
       const newRoutes = [...prevRoutes];
       const route = { ...newRoutes[routeIdx] };
       const points = [...route.points];
@@ -222,13 +330,13 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
   };
 
   const getExportDataUrl = async (ratio, thicknessMultiplier = 1) => {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       if (!stageRef.current) {
         resolve(null);
         return;
       }
 
-      const originals = routes.map(r => r.thickness || 7);
+      const originals = routes.map((r) => r.thickness || 7);
 
       if (thicknessMultiplier !== 1) {
         routes.forEach((route, idx) => {
@@ -240,8 +348,8 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
       const capture = () => {
         const dataURL = stageRef.current.toDataURL({
           pixelRatio: 4,
-          mimeType: 'image/png',
-          backgroundColor: 'white'
+          mimeType: "image/png",
+          backgroundColor: "white",
         });
 
         if (thicknessMultiplier !== 1) {
@@ -282,15 +390,15 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
           logoImg.onload = () => {
             const titleH = 240;
             const brandingH = 240;
-            const canvas = document.createElement('canvas');
+            const canvas = document.createElement("canvas");
             canvas.width = cropW;
             canvas.height = cropH + titleH + brandingH;
-            const ctx = canvas.getContext('2d');
-            ctx.fillStyle = '#fff';
+            const ctx = canvas.getContext("2d");
+            ctx.fillStyle = "#fff";
             ctx.fillRect(0, 0, canvas.width, canvas.height);
 
             // Top area for play title
-            ctx.fillStyle = '#d1d5db';
+            ctx.fillStyle = "#d1d5db";
             ctx.fillRect(0, 0, cropW, titleH);
 
             // Field image
@@ -303,25 +411,25 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
               0,
               titleH,
               cropW,
-              cropH
+              cropH,
             );
 
             // Bottom branding background
-            ctx.fillStyle = '#d1d5db';
+            ctx.fillStyle = "#d1d5db";
             ctx.fillRect(0, titleH + cropH, cropW, brandingH);
 
             // Play title
-            ctx.fillStyle = '#000';
-            ctx.font = 'bold 192px sans-serif';
-            ctx.textAlign = 'center';
-            ctx.textBaseline = 'middle';
-            ctx.fillText(playName || 'Unnamed Play', cropW / 2, titleH / 2);
+            ctx.fillStyle = "#000";
+            ctx.font = "bold 192px sans-serif";
+            ctx.textAlign = "center";
+            ctx.textBaseline = "middle";
+            ctx.fillText(playName || "Unnamed Play", cropW / 2, titleH / 2);
 
             // "made with" text and logo
-            ctx.font = '192px sans-serif';
-            ctx.fillStyle = '#9CA3AF';
-            ctx.textAlign = 'left';
-            const madeWith = 'made with';
+            ctx.font = "192px sans-serif";
+            ctx.fillStyle = "#9CA3AF";
+            ctx.textAlign = "left";
+            const madeWith = "made with";
             const mwWidth = ctx.measureText(madeWith).width;
             const logoHeight = 192;
             const logoWidth = (logoImg.width * logoHeight) / logoImg.height;
@@ -334,10 +442,10 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
               startX + mwWidth + spacing,
               titleH + cropH + brandingH / 2 - logoHeight / 2,
               logoWidth,
-              logoHeight
+              logoHeight,
             );
 
-            resolve(canvas.toDataURL('image/png'));
+            resolve(canvas.toDataURL("image/png"));
           };
         };
       };
@@ -353,9 +461,9 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
   const handleExport = async (ratio) => {
     const url = await getExportDataUrl(ratio);
     if (!url) return;
-    const link = document.createElement('a');
+    const link = document.createElement("a");
     link.href = url;
-    link.download = `${playName || 'play'}.png`;
+    link.download = `${playName || "play"}.png`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -368,19 +476,19 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
     if (navigator.share && navigator.canShare) {
       const res = await fetch(url);
       const blob = await res.blob();
-      const file = new File([blob], `${playName || 'play'}.png`, {
-        type: 'image/png'
+      const file = new File([blob], `${playName || "play"}.png`, {
+        type: "image/png",
       });
       try {
-        await navigator.share({ files: [file], title: playName || 'Play' });
+        await navigator.share({ files: [file], title: playName || "Play" });
         return;
       } catch (e) {
         console.error(e);
       }
     }
-    const link = document.createElement('a');
+    const link = document.createElement("a");
     link.href = url;
-    link.download = `${playName || 'play'}.png`;
+    link.download = `${playName || "play"}.png`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -393,7 +501,10 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
       routes,
       notes,
       name: playName,
-      tags: playTags.split(',').map(tag => tag.trim()).filter(tag => tag !== '')
+      tags: playTags
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter((tag) => tag !== ""),
     });
     const savedStateString = JSON.stringify(savedState);
     return currentState === savedStateString;
@@ -402,9 +513,11 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
   return (
     <div className="flex flex-col bg-gray-900 text-white min-h-screen">
       <div className="w-full text-center mt-2">
-        <h2 className="text-xl font-bold">{playName || 'Unnamed Play'}</h2>
-        <p className={`text-sm ${isPlaySaved() ? 'text-green-400' : 'text-yellow-400'}`}>
-          {isPlaySaved() ? 'All changes saved' : 'Unsaved changes'}
+        <h2 className="text-xl font-bold">{playName || "Unnamed Play"}</h2>
+        <p
+          className={`text-sm ${isPlaySaved() ? "text-green-400" : "text-yellow-400"}`}
+        >
+          {isPlaySaved() ? "All changes saved" : "Unsaved changes"}
         </p>
       </div>
 
@@ -444,7 +557,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
                 />
                 <label className="block mt-2 mb-1">Color</label>
                 <div className="flex gap-2 flex-wrap">
-                  {colorOptions.map(color => (
+                  {colorOptions.map((color) => (
                     <button
                       key={color}
                       className="w-6 h-6 rounded-full border border-white"
@@ -459,7 +572,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
                   onChange={(e) => handleShapeChange(e.target.value)}
                   className="w-full p-1 rounded text-white bg-gray-700"
                 >
-                  {shapeOptions.map(shape => (
+                  {shapeOptions.map((shape) => (
                     <option key={shape} value={shape}>
                       {shape.charAt(0).toUpperCase() + shape.slice(1)}
                     </option>
@@ -497,7 +610,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
                 <label className="block mt-2 mb-1">Line Style</label>
                 <select
                   value={routes[selectedRouteIndex].style}
-                  onChange={(e) => updateRouteProperty('style', e.target.value)}
+                  onChange={(e) => updateRouteProperty("style", e.target.value)}
                   className="w-full p-1 rounded text-white bg-gray-700"
                 >
                   <option value="solid">Solid</option>
@@ -507,7 +620,12 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
                 <label className="block mt-2 mb-1">Line Thickness</label>
                 <select
                   value={routes[selectedRouteIndex].thickness || 7}
-                  onChange={(e) => updateRouteProperty('thickness', parseInt(e.target.value, 10))}
+                  onChange={(e) =>
+                    updateRouteProperty(
+                      "thickness",
+                      parseInt(e.target.value, 10),
+                    )
+                  }
                   className="w-full p-1 rounded text-white bg-gray-700"
                 >
                   <option value={5}>Thin</option>
@@ -518,10 +636,12 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
                 <label className="block mt-2 mb-1">End Marker</label>
                 <select
                   value={routes[selectedRouteIndex].endMarker}
-                  onChange={(e) => updateRouteProperty('endMarker', e.target.value)}
+                  onChange={(e) =>
+                    updateRouteProperty("endMarker", e.target.value)
+                  }
                   className="w-full p-1 rounded text-white bg-gray-700"
                 >
-                  {endMarkerOptions.map(marker => (
+                  {endMarkerOptions.map((marker) => (
                     <option key={marker} value={marker}>
                       {marker.charAt(0).toUpperCase() + marker.slice(1)}
                     </option>
@@ -532,7 +652,12 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
                   <input
                     type="checkbox"
                     checked={routes[selectedRouteIndex].smooth}
-                    onChange={() => updateRouteProperty('smooth', !routes[selectedRouteIndex].smooth)}
+                    onChange={() =>
+                      updateRouteProperty(
+                        "smooth",
+                        !routes[selectedRouteIndex].smooth,
+                      )
+                    }
                     className="form-checkbox h-4 w-4"
                   />
                   <span>Smooth</span>
@@ -554,13 +679,15 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
                 <input
                   type="text"
                   value={notes[selectedNoteIndex].text}
-                  onChange={(e) => updateNoteProperty('text', e.target.value)}
+                  onChange={(e) => updateNoteProperty("text", e.target.value)}
                   className="w-full p-1 rounded text-white bg-gray-700"
                 />
                 <label className="block mt-2 mb-1">Font Color</label>
                 <select
                   value={notes[selectedNoteIndex].fontColor}
-                  onChange={(e) => updateNoteProperty('fontColor', e.target.value)}
+                  onChange={(e) =>
+                    updateNoteProperty("fontColor", e.target.value)
+                  }
                   className="w-full p-1 rounded text-white bg-gray-700"
                 >
                   <option value="#000000">Black</option>
@@ -569,7 +696,9 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
                 <label className="block mt-2 mb-1">Font Size</label>
                 <select
                   value={notes[selectedNoteIndex].fontSize}
-                  onChange={(e) => updateNoteProperty('fontSize', parseInt(e.target.value))}
+                  onChange={(e) =>
+                    updateNoteProperty("fontSize", parseInt(e.target.value))
+                  }
                   className="w-full p-1 rounded text-white bg-gray-700"
                 >
                   <option value={12}>Small</option>
@@ -578,12 +707,14 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
                 </select>
                 <label className="block mt-2 mb-1">Background Color</label>
                 <div className="flex gap-2 flex-wrap">
-                  {colorOptions.map(color => (
+                  {colorOptions.map((color) => (
                     <button
                       key={color}
                       className="w-6 h-6 rounded-full border border-white"
                       style={{ backgroundColor: color }}
-                      onClick={() => updateNoteProperty('backgroundColor', color)}
+                      onClick={() =>
+                        updateNoteProperty("backgroundColor", color)
+                      }
                     />
                   ))}
                 </div>
@@ -591,7 +722,9 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
                   <input
                     type="checkbox"
                     checked={notes[selectedNoteIndex].bold}
-                    onChange={() => updateNoteProperty('bold', !notes[selectedNoteIndex].bold)}
+                    onChange={() =>
+                      updateNoteProperty("bold", !notes[selectedNoteIndex].bold)
+                    }
                     className="form-checkbox h-4 w-4"
                   />
                   <span>Bold Text</span>
@@ -600,7 +733,12 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
                   <input
                     type="checkbox"
                     checked={notes[selectedNoteIndex].border}
-                    onChange={() => updateNoteProperty('border', !notes[selectedNoteIndex].border)}
+                    onChange={() =>
+                      updateNoteProperty(
+                        "border",
+                        !notes[selectedNoteIndex].border,
+                      )
+                    }
                     className="form-checkbox h-4 w-4"
                   />
                   <span>Border</span>
@@ -640,6 +778,12 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
             >
               Save Play
             </button>
+            <button
+              onClick={handleSaveAs}
+              className="w-full mt-2 bg-blue-600 hover:bg-blue-500 px-4 py-2 rounded text-white"
+            >
+              Save As
+            </button>
           </aside>
         </div>
       </main>
@@ -674,4 +818,3 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
 };
 
 export default PlayEditor;
-


### PR DESCRIPTION
## Summary
- add `handleSaveAs` to save a copy under a new name with a deep-cloned state
- expose Save As button in the Save Play panel

## Testing
- `npx prettier -c src/PlayEditor.jsx`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842202878448324bbdaac7743332962