### PR TITLE
Add defensive formation rendering

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -40,6 +40,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
   const [playTags, setPlayTags] = useState('');
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [savedState, setSavedState] = useState(null);
+  const [defenseFormation, setDefenseFormation] = useState('No');
   const stageRef = useRef(null);
 
   useEffect(() => {
@@ -425,6 +426,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
           setSelectedNoteIndex={setSelectedNoteIndex}
           handlePointDrag={handlePointDrag}
           stageRef={stageRef}
+          defenseFormation={defenseFormation}
         />
 
         <div className="flex flex-col gap-4 w-60">
@@ -609,18 +611,34 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
             ) : (
               <p className="text-sm">Select a note to edit.</p>
             )}
-            <button
-              className="bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded mt-2"
-              onClick={handleAddNote}
-            >
-              Add Note
-            </button>
-          </aside>
+          <button
+            className="bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded mt-2"
+            onClick={handleAddNote}
+          >
+            Add Note
+          </button>
+        </aside>
 
-          {/* Save Play */}
-          <aside className="bg-gray-800 p-4 rounded">
-            <h2 className="text-lg font-bold mb-2">Save Play</h2>
-            <input
+        {/* Defense Options */}
+        <aside className="bg-gray-800 p-4 rounded">
+          <h2 className="text-lg font-bold mb-2">Defense Formation</h2>
+          <select
+            value={defenseFormation}
+            onChange={(e) => setDefenseFormation(e.target.value)}
+            className="w-full p-1 rounded text-white bg-gray-700"
+          >
+            <option value="No">No</option>
+            <option value="1-3-1">1-3-1</option>
+            <option value="3-2">3-2</option>
+            <option value="4-1">4-1</option>
+            <option value="2-3">2-3</option>
+          </select>
+        </aside>
+
+        {/* Save Play */}
+        <aside className="bg-gray-800 p-4 rounded">
+          <h2 className="text-lg font-bold mb-2">Save Play</h2>
+          <input
               type="text"
               value={playName}
               onChange={(e) => setPlayName(e.target.value)}

--- a/src/components/FootballField.jsx
+++ b/src/components/FootballField.jsx
@@ -12,7 +12,8 @@ import {
   Text,
   Group,
   Label,
-  Tag
+  Tag,
+  RegularPolygon
 } from 'react-konva';
 import { line as d3Line, curveBasis, curveLinear } from 'd3-shape';
 
@@ -55,12 +56,45 @@ const FootballField = ({
   selectedNoteIndex,
   setSelectedNoteIndex,
   handlePointDrag,
-  stageRef
+  stageRef,
+  defenseFormation
 }) => {
   const width = 800;
   const height = 600;
   const lineOfScrimmageY = height - 250;
   const yardLineSpacing = 55;
+
+  const getDefensePositions = (formation) => {
+    if (!formation || formation === 'No') return [];
+    const rowSpacing = 60;
+    let rows;
+    switch (formation) {
+      case '1-3-1':
+        rows = [1, 3, 1];
+        break;
+      case '3-2':
+        rows = [3, 2];
+        break;
+      case '4-1':
+        rows = [4, 1];
+        break;
+      case '2-3':
+        rows = [2, 3];
+        break;
+      default:
+        return [];
+    }
+    const startY = lineOfScrimmageY - rows.length * rowSpacing;
+    const positions = [];
+    rows.forEach((count, rIdx) => {
+      const y = startY + rIdx * rowSpacing;
+      const spacing = width / (count + 1);
+      for (let i = 0; i < count; i++) {
+        positions.push({ x: spacing * (i + 1), y });
+      }
+    });
+    return positions;
+  };
 
   const localStageRef = useRef(null);
   const layerRef = useRef(null);
@@ -106,6 +140,8 @@ const FootballField = ({
     const newY = Math.max(radius, Math.min(height - radius, pos.y));
     return { x: newX, y: newY };
   };
+
+  const defensePositions = getDefensePositions(defenseFormation);
 
   const handleDragEnd = (e, index) => {
     const updatedPlayers = [...players];
@@ -376,7 +412,22 @@ const FootballField = ({
               offsetX={12}
               offsetY={12}
               x={3}
-              y={4}
+            y={4}
+          />
+        </Group>
+        ))}
+
+        {/* Defensive Players */}
+        {defensePositions.map((pos, idx) => (
+          <Group key={`def-${idx}`} x={pos.x} y={pos.y}>
+            <RegularPolygon
+              x={0}
+              y={0}
+              sides={3}
+              radius={25}
+              fill="#6B7280"
+              rotation={180}
+              cornerRadius={5}
             />
           </Group>
         ))}


### PR DESCRIPTION
## Summary
- add `defenseFormation` state to PlayEditor
- allow choosing defensive formation via a new section
- pass formation state to `FootballField`
- compute defender positions and render grey triangles for selected formations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842202bde0c8324bfd32f5b64bbabd4