### PR TITLE
Fix save flow and playbook management

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -86,6 +86,8 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
   const [playName, setPlayName] = useState("");
   const [playTags, setPlayTags] = useState("");
   const [showSaveModal, setShowSaveModal] = useState(false);
+  const [showSaveAsModal, setShowSaveAsModal] = useState(false);
+  const [saveAsName, setSaveAsName] = useState('');
   const [savedState, setSavedState] = useState(null);
   const [defenseFormation, setDefenseFormation] = useState('No');
   const stageRef = useRef(null);
@@ -173,23 +175,18 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
     });
   };
 
-  const handleSaveAs = async () => {
+  const handleSaveAs = () => {
     if (!auth.currentUser) {
       openSignIn();
       return;
     }
 
-    let newName = prompt("Enter a name for the new play:", playName);
-    if (newName !== null) {
-      newName = newName.trim();
-      if (newName) {
-        setPlayName(newName);
-      } else {
-        newName = playName;
-      }
-    } else {
-      newName = playName;
-    }
+    setSaveAsName(playName);
+    setShowSaveAsModal(true);
+  };
+
+  const handleSaveAsConfirm = async () => {
+    const newName = saveAsName.trim() || playName;
 
     const dataURL = await getExportDataUrl(4 / 3);
     const playKey = `Play-${Date.now()}`;
@@ -200,16 +197,18 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
       notes,
       name: newName,
       tags: playTags
-        .split(",")
+        .split(',')
         .map((tag) => tag.trim())
-        .filter((tag) => tag !== ""),
+        .filter((tag) => tag !== ''),
       image: dataURL,
     };
 
     await setDoc(
-      doc(db, "users", auth.currentUser.uid, "plays", playKey),
+      doc(db, 'users', auth.currentUser.uid, 'plays', playKey),
       playData,
     );
+    setPlayName(newName);
+    setShowSaveAsModal(false);
     setShowSaveModal(true);
 
     setSavedState(
@@ -220,9 +219,9 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
           notes,
           name: newName,
           tags: playTags
-            .split(",")
+            .split(',')
             .map((tag) => tag.trim())
-            .filter((tag) => tag !== ""),
+            .filter((tag) => tag !== ''),
         }),
       ),
     );
@@ -817,6 +816,34 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
           />
         </div>
       </div>
+
+      {showSaveAsModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white text-black rounded p-4 w-80">
+            <h2 className="text-lg font-bold mb-2">Save Play As</h2>
+            <input
+              type="text"
+              value={saveAsName}
+              onChange={(e) => setSaveAsName(e.target.value)}
+              className="w-full p-1 rounded border mb-2"
+            />
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setShowSaveAsModal(false)}
+                className="px-3 py-1 rounded bg-gray-300"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSaveAsConfirm}
+                className="px-3 py-1 rounded bg-blue-600 text-white"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {showSaveModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">

--- a/src/components/AddToPlaybookModal.jsx
+++ b/src/components/AddToPlaybookModal.jsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react';
+import { db, auth } from '../firebase';
+import { collection, getDocs, doc, getDoc, setDoc } from 'firebase/firestore';
 
 const AddToPlaybookModal = ({ playId, onClose }) => {
   const [playbooks, setPlaybooks] = useState([]);
@@ -6,31 +8,68 @@ const AddToPlaybookModal = ({ playId, onClose }) => {
   const [newBookName, setNewBookName] = useState('');
 
   useEffect(() => {
-    const books = [];
-    for (let key in localStorage) {
-      if (key.startsWith('Playbook-')) {
-        try {
-          const book = JSON.parse(localStorage.getItem(key));
-          books.push(book);
-        } catch (e) {
-          // ignore bad data
+    const fetchBooks = async () => {
+      if (auth.currentUser) {
+        const snap = await getDocs(
+          collection(db, 'users', auth.currentUser.uid, 'playbooks')
+        );
+        const arr = [];
+        snap.forEach(d => arr.push(d.data()));
+        setPlaybooks(arr);
+        if (arr.length > 0) setSelectedBookId(arr[0].id);
+      } else {
+        const books = [];
+        for (let key in localStorage) {
+          if (key.startsWith('Playbook-')) {
+            try {
+              const book = JSON.parse(localStorage.getItem(key));
+              books.push(book);
+            } catch (e) {
+              // ignore bad data
+            }
+          }
         }
+        setPlaybooks(books);
+        if (books.length > 0) setSelectedBookId(books[0].id);
       }
-    }
-    setPlaybooks(books);
-    if (books.length > 0) setSelectedBookId(books[0].id);
+    };
+    fetchBooks();
   }, []);
 
-  const handleAdd = () => {
+  const handleAdd = async () => {
     if (newBookName.trim()) {
       const id = `Playbook-${Date.now()}`;
       const book = { id, name: newBookName.trim(), playIds: [playId] };
-      localStorage.setItem(id, JSON.stringify(book));
+      if (auth.currentUser) {
+        await setDoc(
+          doc(db, 'users', auth.currentUser.uid, 'playbooks', id),
+          book
+        );
+      } else {
+        localStorage.setItem(id, JSON.stringify(book));
+      }
     } else if (selectedBookId) {
-      const book = JSON.parse(localStorage.getItem(selectedBookId));
-      if (!book.playIds.includes(playId)) {
-        book.playIds.push(playId);
-        localStorage.setItem(selectedBookId, JSON.stringify(book));
+      if (auth.currentUser) {
+        const ref = doc(
+          db,
+          'users',
+          auth.currentUser.uid,
+          'playbooks',
+          selectedBookId
+        );
+        const snap = await getDoc(ref);
+        if (snap.exists()) {
+          const data = snap.data();
+          if (!data.playIds.includes(playId)) {
+            await setDoc(ref, { ...data, playIds: [...data.playIds, playId] });
+          }
+        }
+      } else {
+        const book = JSON.parse(localStorage.getItem(selectedBookId));
+        if (book && !book.playIds.includes(playId)) {
+          book.playIds.push(playId);
+          localStorage.setItem(selectedBookId, JSON.stringify(book));
+        }
       }
     }
     onClose();

--- a/src/components/FootballField.jsx
+++ b/src/components/FootballField.jsx
@@ -196,8 +196,10 @@ const FootballField = ({
       setUndoStack((prev) => [
         ...prev,
         {
-          routes: JSON.parse(JSON.stringify(routes))
-        }
+          players: JSON.parse(JSON.stringify(players)),
+          routes: JSON.parse(JSON.stringify(routes)),
+          notes: JSON.parse(JSON.stringify(notes)),
+        },
       ]);
 
       let newRoutes = [...routes];


### PR DESCRIPTION
## Summary
- fix undo stack corruption when adding routes
- support Firebase playbooks in AddToPlaybookModal
- replace Save As prompt with custom modal

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6842349dba948324bfa6b235d1b4e6f6