### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -522,7 +522,8 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
         </p>
       </div>
 
-      <main className="flex flex-row items-start mt-4 px-4 w-full max-w-7xl mx-auto gap-4">
+      <main className="flex flex-col lg:flex-row items-start mt-4 px-4 w-full max-w-7xl mx-auto gap-4">
+        <div className="overflow-x-auto">
         <FootballField
           players={players}
           setPlayers={setPlayers}
@@ -541,8 +542,9 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
           stageRef={stageRef}
           defenseFormation={defenseFormation}
         />
+        </div>
 
-        <div className="flex flex-col gap-4 w-60">
+        <div className="flex flex-col gap-4 w-full lg:w-60">
           {/* Player Editor */}
           <aside className="bg-gray-800 p-4 rounded">
             <h2 className="text-lg font-bold flex items-center mb-2">
@@ -819,7 +821,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
 
       {showSaveAsModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white text-black rounded p-4 w-80">
+          <div className="bg-white text-black rounded p-4 w-full max-w-sm">
             <h2 className="text-lg font-bold mb-2">Save Play As</h2>
             <input
               type="text"

--- a/src/components/AddToPlaybookModal.jsx
+++ b/src/components/AddToPlaybookModal.jsx
@@ -77,7 +77,7 @@ const AddToPlaybookModal = ({ playId, onClose }) => {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white text-black rounded p-4 w-80">
+      <div className="bg-white text-black rounded p-4 w-full max-w-sm">
         <h2 className="text-lg font-bold mb-2">Add to Playbook</h2>
         {playbooks.length > 0 && (
           <>

--- a/src/components/PlayLibrary.jsx
+++ b/src/components/PlayLibrary.jsx
@@ -61,7 +61,7 @@ const PlayLibrary = ({ onSelectPlay, user, openSignIn }) => {
           <option value={100}>Show 100</option>
         </select>
       </div>
-      <div className="grid grid-cols-4 gap-4">
+      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
         {displayedPlays.map((play) => (
           <div
             key={play.id}

--- a/src/components/PlaybookLibrary.jsx
+++ b/src/components/PlaybookLibrary.jsx
@@ -283,7 +283,7 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
           </div>
 
           {!collapsed[book.id] && (
-            <div className="grid grid-cols-4 gap-4">
+            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
               {book.playIds.map((pid, idx) => {
                 const play = getPlay(pid);
                 if (!play) return null;

--- a/src/components/PrintOptionsModal.jsx
+++ b/src/components/PrintOptionsModal.jsx
@@ -66,7 +66,7 @@ const PrintOptionsModal = ({ onClose, onPrint }) => {
                 <option value="8">8 plays</option>
               </select>
             </div>
-            <div className="mb-2 grid grid-cols-2 gap-2">
+            <div className="mb-2 grid grid-cols-1 sm:grid-cols-2 gap-2">
               <div>
                 <label className="block mb-1">Width</label>
                 <select

--- a/src/components/SignInModal.jsx
+++ b/src/components/SignInModal.jsx
@@ -30,7 +30,7 @@ const SignInModal = ({ onClose }) => {
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="relative bg-gray-800 text-white rounded p-6 w-80">
+      <div className="relative bg-gray-800 text-white rounded p-6 w-full max-w-sm">
         <button
           className="absolute top-2 right-2 text-gray-400 hover:text-white"
           onClick={onClose}


### PR DESCRIPTION
## Summary
- make grid layouts responsive
- stack PlayEditor layout on small screens and allow horizontal scrolling for the field
- size modals relative to viewport

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684236ad26e483248e75ef77076d61af