### PR TITLE
Add print images

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -5,6 +5,7 @@ import FootballField from "./components/FootballField";
 import Toolbar from "./components/Toolbar";
 import { User, ArrowRight, Trash2, StickyNote } from "lucide-react";
 import huddlupLogo from "./assets/huddlup_logo_2.svg";
+import { THICKNESS_MULTIPLIER } from "./components/PrintOptionsModal";
 
 const width = 800;
 const height = 600;
@@ -161,6 +162,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
     }
 
     const dataURL = await getExportDataUrl(4 / 3);
+    const printURL = await getExportDataUrl(4 / 3, THICKNESS_MULTIPLIER);
 
     const playKey = `Play-${Date.now()}`;
     const playData = {
@@ -174,6 +176,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
         .map((tag) => tag.trim())
         .filter((tag) => tag !== ""),
       image: dataURL,
+      printImage: printURL,
     };
 
     await setDoc(
@@ -198,6 +201,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
     const newName = saveAsName.trim() || playName;
 
     const dataURL = await getExportDataUrl(4 / 3);
+    const printURL = await getExportDataUrl(4 / 3, THICKNESS_MULTIPLIER);
     const playKey = `Play-${Date.now()}`;
     const playData = {
       id: playKey,
@@ -210,6 +214,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
         .map((tag) => tag.trim())
         .filter((tag) => tag !== ''),
       image: dataURL,
+      printImage: printURL,
     };
 
     await setDoc(

--- a/src/components/PlaybookLibrary.jsx
+++ b/src/components/PlaybookLibrary.jsx
@@ -146,7 +146,13 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
       return;
     }
 
-    const plays = book.playIds.map(pid => getPlay(pid)).filter(Boolean);
+    const plays = book.playIds
+      .map(pid => getPlay(pid))
+      .filter(Boolean)
+      .map(p => ({
+        ...p,
+        displayImage: p.printImage || p.image,
+      }));
 
     const w = window.open('', '_blank');
     if (!w) return;
@@ -212,7 +218,7 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
             if (includeTitle) w.document.write(`<div class="title">${play.name}</div>`);
             w.document.write('</div>');
           }
-          if (play.image) w.document.write(`<img src="${play.image}" />`);
+          if (play.displayImage) w.document.write(`<img src="${play.displayImage}" />`);
           w.document.write('</div>');
         });
         w.document.write('</div>');
@@ -230,7 +236,7 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
             if (includeTitle) w.document.write(`<div class="title">${play.name}</div>`);
             w.document.write('</div>');
           }
-          if (play.image) w.document.write(`<img src="${play.image}" />`);
+          if (play.displayImage) w.document.write(`<img src="${play.displayImage}" />`);
           w.document.write('</div>');
         });
         w.document.write('</div>');
@@ -318,9 +324,9 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
                       </button>
                     </div>
 
-                    {play.image ? (
+                    {play.displayImage ? (
                       <img
-                        src={play.image}
+                        src={play.displayImage}
                         alt={play.name}
                         className="w-full h-40 object-contain rounded mb-2 bg-white"
                       />


### PR DESCRIPTION
## Summary
- include THICKNESS_MULTIPLIER constant in `PlayEditor`
- save an additional `printImage` for plays
- use `printImage` in `PlaybookLibrary` printouts and previews

## Testing
- `npm test --silent`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684259a9058c8324a96e39ce94ba9a14