### PR TITLE
Fix landing page header and hero background

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { BrowserRouter as Router, Routes, Route, Link, useNavigate } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Link, useNavigate, useLocation } from 'react-router-dom';
 import { onAuthStateChanged, signOut } from 'firebase/auth';
 import { auth } from './firebase';
 import PlayEditor from './PlayEditor';
@@ -14,6 +14,7 @@ const AppContent = ({ user, openSignIn }) => {
 
   const [selectedPlay, setSelectedPlay] = useState(null);
   const navigate = useNavigate();
+  const location = useLocation();
 
   const handleLoadPlay = (play) => {
     setSelectedPlay(play);
@@ -23,6 +24,7 @@ const AppContent = ({ user, openSignIn }) => {
   return (
     <div className="min-h-screen flex flex-col bg-gray-900 text-white">
       {/* Header */}
+      {location.pathname !== '/landing' && (
       <header className="w-full bg-gray-800">
         <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-2">
           <div className="flex items-center space-x-3">
@@ -76,6 +78,7 @@ const AppContent = ({ user, openSignIn }) => {
 
         </div>
       </header>
+      )}
 
       {/* Main Content */}
       <main className="flex-grow">

--- a/src/LandingPage.jsx
+++ b/src/LandingPage.jsx
@@ -11,7 +11,7 @@ const LandingPage = () => {
         <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-2">
           <div className="flex items-center space-x-3">
             <img src={logo} alt="HuddlUp Logo" className="h-8" />
-            <h1 className="text-xl font-bold">huddlup</h1>
+            <h1 className="text-xl font-bold">Flag Football Play Designer</h1>
           </div>
           <Link
             to="/"
@@ -23,7 +23,7 @@ const LandingPage = () => {
       </header>
 
       {/* Hero */}
-      <section className="hero flex flex-col items-center justify-center text-center py-20 relative">
+      <section className="hero flex flex-col items-center justify-center text-center py-20 relative bg-[repeating-linear-gradient(135deg,#1f2937_0px,#1f2937_10px,#111827_10px,#111827_20px)]">
         <img src={playImage} alt="Play Design" className="max-w-md mb-6 z-10" />
         <h2 className="text-4xl font-bold mb-4">Design. Huddle. Dominate.</h2>
         <Link


### PR DESCRIPTION
## Summary
- don't show application header on the landing page
- update the landing page header text
- add repeating gradient to landing hero section

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842ce08ad788324a853b13a688e95a0