### PR TITLE
Set landing page as home

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,7 +17,7 @@ const AppContent = ({ user, openSignIn }) => {
 
   const handleLoadPlay = (play) => {
     setSelectedPlay(play);
-    navigate('/');  // Use navigate to stay within SPA and preserve state
+    navigate('/editor');  // Use navigate to stay within SPA and preserve state
   };
 
   return (
@@ -31,13 +31,13 @@ const AppContent = ({ user, openSignIn }) => {
           </div>
           <nav className="flex flex-wrap gap-2 items-center">
             <Link
-              to="/landing"
+              to="/"
               className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
             >
               Home
             </Link>
             <Link
-              to="/"
+              to="/editor"
               className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
             >
               <Home className="w-4 h-4 mr-1" /> Editor
@@ -80,9 +80,10 @@ const AppContent = ({ user, openSignIn }) => {
       {/* Main Content */}
       <main className="flex-grow">
         <Routes>
+          <Route path="/" element={<LandingPage />} />
           <Route path="/landing" element={<LandingPage />} />
           <Route
-            path="/"
+            path="/editor"
             element={<PlayEditor loadedPlay={selectedPlay} openSignIn={openSignIn} />}
           />
           <Route

--- a/src/LandingPage.jsx
+++ b/src/LandingPage.jsx
@@ -14,7 +14,7 @@ const LandingPage = () => {
             <h1 className="text-xl font-bold">huddlup</h1>
           </div>
           <Link
-            to="/"
+            to="/editor"
             className="bg-[#7AC142] text-black font-semibold px-4 py-1 rounded hover:bg-[#002A5C] hover:text-white"
           >
             Get Started
@@ -27,7 +27,7 @@ const LandingPage = () => {
         <img src={playImage} alt="Play Design" className="max-w-md mb-6 z-10" />
         <h2 className="text-4xl font-bold mb-4">Design. Huddle. Dominate.</h2>
         <Link
-          to="/"
+          to="/editor"
           className="bg-[#7AC142] text-black px-6 py-3 rounded font-semibold hover:bg-[#002A5C] hover:text-white transition-colors z-10"
         >
           Get Started


### PR DESCRIPTION
## Summary
- make landing page load at `/`
- move editor to `/editor`
- update navigation and links accordingly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842cf2befe48324b96452e3fe8bb77f