### PR TITLE
Add setup script and lint instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,7 @@ VITE_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
 VITE_FIREBASE_APP_ID=your_app_id
 ```
 
-Install dependencies and start the dev server with `npm run dev`.
+Run `npm run setup` (or `npm ci`) to install all dependencies, then start the dev server with `npm run dev`.
+
+Lint the project with `npm run lint`.
 

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "start": "vite",
-    "build": "vite build",
-    "lint": "eslint .",
-    "preview": "vite preview"
-  },
+    "scripts": {
+      "setup": "npm ci",
+      "dev": "vite",
+      "start": "vite",
+      "build": "vite build",
+      "lint": "eslint .",
+      "preview": "vite preview"
+    },
   "dependencies": {
     "d3-shape": "^3.2.0",
     "fabric": "^6.6.7",


### PR DESCRIPTION
## Summary
- add `npm run setup` script
- document dependency setup and lint command in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842e62519188324bb2bdcafa10c7fcb