### PR TITLE
Remove env from repo and add example

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,0 @@
-VITE_FIREBASE_API_KEY=AIzaSyDld0L_p93d9-KvaLv_xoD3RAFsI6vT5S8
-VITE_FIREBASE_AUTH_DOMAIN=huddlup-v1.firebaseapp.com
-VITE_FIREBASE_PROJECT_ID=huddlup-v1
-VITE_FIREBASE_STORAGE_BUCKET=huddlup-v1.appspot.com
-VITE_FIREBASE_MESSAGING_SENDER_ID=245860582575
-VITE_FIREBASE_APP_ID= # You’ll find this in your Firebase console under Project settings > General > “Your apps” (look for App ID in the config snippet)

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+VITE_FIREBASE_API_KEY=your_api_key
+VITE_FIREBASE_AUTH_DOMAIN=your_auth_domain
+VITE_FIREBASE_PROJECT_ID=your_project_id
+VITE_FIREBASE_STORAGE_BUCKET=your_storage_bucket
+VITE_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
+VITE_FIREBASE_APP_ID=your_app_id

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment files
+.env
+.env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you are developing a production application, we recommend using TypeScript wi
 
 ## Firebase Setup
 
-Authentication and play storage now use Firebase. Create a Firebase project and set the following environment variables in a `.env` file:
+Authentication and play storage now use Firebase. Copy `.env.example` to `.env` and set the following environment variables with your Firebase credentials:
 
 ```
 VITE_FIREBASE_API_KEY=your_api_key


### PR DESCRIPTION
## Summary
- stop tracking `.env` and ignore env files
- add `.env.example` template
- instruct users to copy the example file before running the app

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842e85865148324a10623c98a37e837