### PR TITLE
Fix landing page image import

### DIFF
--- a/src/LandingPage.jsx
+++ b/src/LandingPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import logo from './assets/huddlup_logo_white_w_trans.png';
-import playImage from new URL('./assets/test_play_for_marketing.png', import.meta.url);
+import playImage from './assets/test_play_for_marketing.png';
 
 const LandingPage = () => {
   return (


### PR DESCRIPTION
## Summary
- fix landing page image import syntax so Vite can build

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e9e2f4ac83249ec62528469729bc