### PR TITLE
Fix base path for deployment

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,8 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  // Use relative paths so the app can be served from any subdirectory
+  base: './',
   plugins: [react()],
   css: {
     postcss: './postcss.config.cjs'


### PR DESCRIPTION
## Summary
- configure Vite to use relative paths so deployed builds can load assets

## Testing
- `npm run lint` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_6843134408dc8324b996101916530540