### PR TITLE
feat: enforce Firebase env var validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ VITE_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
 VITE_FIREBASE_APP_ID=your_app_id
 ```
 
+All of these variables are required. The application will throw an error on
+startup if any values are missing.
+
 Run `npm run setup` (or `npm ci`) to install all dependencies, then start the dev server with `npm run dev`.
 
 Lint the project with `npm run lint`.

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -16,8 +16,8 @@ const missing = Object.entries(firebaseConfig)
   .map(([key]) => key);
 
 if (missing.length) {
-  console.warn(
-    `Firebase configuration is missing values for: ${missing.join(', ')}.\n` +
+  throw new Error(
+    `Missing Firebase configuration for: ${missing.join(', ')}.\n` +
       'Check your environment variables.'
   );
 }


### PR DESCRIPTION
## Summary
- require Firebase env vars and throw an error when any are missing
- document this strict validation in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684316ac00b48324a2fe1fa7d91a305b