### PR TITLE
Remove nav header from landing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,7 +24,7 @@ const AppContent = ({ user, openSignIn }) => {
   return (
     <div className="min-h-screen flex flex-col bg-gray-900 text-white">
       {/* Header */}
-      {location.pathname !== '/landing' && (
+      {location.pathname !== '/landing' && location.pathname !== '/' && (
       <header className="w-full bg-gray-800">
         <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-2">
           <div className="flex items-center space-x-3">


### PR DESCRIPTION
## Summary
- keep the nav header hidden when visiting the landing page at `/`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68431f9bdf2083249ba0adb9eef901dd