### PR TITLE
Fix playbook modal success handling

### DIFF
--- a/src/components/AddToPlaybookModal.jsx
+++ b/src/components/AddToPlaybookModal.jsx
@@ -106,7 +106,7 @@ const AddToPlaybookModal = ({ playId, onClose }) => {
         />
         <div className="flex justify-end gap-2 mt-2">
           <button
-            onClick={onClose}
+            onClick={() => onClose(false)}
             className="px-3 py-1 rounded bg-gray-300"
           >
             Cancel

--- a/src/components/PlayLibrary.jsx
+++ b/src/components/PlayLibrary.jsx
@@ -120,7 +120,7 @@ const PlayLibrary = ({ onSelectPlay, user, openSignIn }) => {
       )}
       {showConfirmation && (
         <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-green-600 text-white px-4 py-2 rounded shadow">
-          Play added to playbook
+          Play successfully added to playbook
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- ensure cancel doesn't trigger success state
- improve confirmation message when a play is added to a playbook

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684322265b9c8324818a00eebb82c834