### PR TITLE
Apply sleek dark theme

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,10 +22,10 @@ const AppContent = ({ user, openSignIn }) => {
   };
 
   return (
-    <div className="min-h-screen flex flex-col bg-gray-900 text-white">
+    <div className="min-h-screen flex flex-col text-gray-100">
       {/* Header */}
       {location.pathname !== '/landing' && location.pathname !== '/' && (
-      <header className="w-full bg-gray-800">
+      <header className="w-full bg-gray-800/80 shadow">
         <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-2">
           <div className="flex items-center space-x-3">
             <img src={logo} alt="HuddlUp Logo" className="h-8" />
@@ -34,25 +34,25 @@ const AppContent = ({ user, openSignIn }) => {
           <nav className="flex flex-wrap gap-2 items-center">
             <Link
               to="/"
-              className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+              className="flex items-center btn-dark"
             >
               Home
             </Link>
             <Link
               to="/editor"
-              className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+              className="flex items-center btn-dark"
             >
               <Home className="w-4 h-4 mr-1" /> Editor
             </Link>
             <Link
               to="/library"
-              className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+              className="flex items-center btn-dark"
             >
               <Book className="w-4 h-4 mr-1" /> Play Library
             </Link>
             <Link
               to="/playbooks"
-              className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+              className="flex items-center btn-dark"
             >
               <BookOpen className="w-4 h-4 mr-1" /> Playbooks
             </Link>
@@ -61,7 +61,7 @@ const AppContent = ({ user, openSignIn }) => {
                 <span className="mx-2 text-sm">{user.email}</span>
                 <button
                   onClick={() => signOut(auth)}
-                  className="bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+                  className="btn-dark"
                 >
                   Sign Out
                 </button>
@@ -69,7 +69,7 @@ const AppContent = ({ user, openSignIn }) => {
             ) : (
               <button
                 onClick={openSignIn}
-                className="bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+                className="btn-dark"
               >
                 Sign In
               </button>

--- a/src/LandingPage.jsx
+++ b/src/LandingPage.jsx
@@ -5,9 +5,9 @@ import playImage from './assets/test_play_for_marketing.png';
 
 const LandingPage = () => {
   return (
-    <div className="min-h-screen flex flex-col bg-black text-white">
+    <div className="min-h-screen flex flex-col text-gray-100">
       {/* Header */}
-      <header className="w-full bg-gray-800">
+      <header className="w-full bg-gray-800/80 shadow">
         <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-2">
           <div className="flex items-center space-x-3">
             <img src={logo} alt="HuddlUp Logo" className="h-8" />
@@ -15,7 +15,7 @@ const LandingPage = () => {
           </div>
           <Link
             to="/editor"
-            className="bg-[#7AC142] text-black font-semibold px-4 py-1 rounded hover:bg-[#002A5C] hover:text-white"
+            className="btn-dark font-semibold px-4 py-1"
           >
             Get Started
           </Link>
@@ -28,32 +28,32 @@ const LandingPage = () => {
         <h2 className="text-4xl font-bold mb-4">Design. Huddle. Dominate.</h2>
         <Link
           to="/editor"
-          className="bg-[#7AC142] text-black px-6 py-3 rounded font-semibold hover:bg-[#002A5C] hover:text-white transition-colors z-10"
+          className="btn-dark font-semibold px-6 py-3"
         >
           Get Started
         </Link>
       </section>
 
       {/* Features */}
-      <section className="py-16 bg-gray-900">
+      <section className="py-16 bg-gray-800/70">
         <div className="max-w-5xl mx-auto grid md:grid-cols-3 gap-8 text-center">
           <div className="p-4">
-            <h3 className="text-xl font-semibold mb-2 text-[#7AC142]">Design Plays</h3>
+            <h3 className="text-xl font-semibold mb-2 text-gray-200">Design Plays</h3>
             <p>Create and customize flag football plays with ease.</p>
           </div>
           <div className="p-4">
-            <h3 className="text-xl font-semibold mb-2 text-[#7AC142]">Collaborate &amp; Share</h3>
+            <h3 className="text-xl font-semibold mb-2 text-gray-200">Collaborate &amp; Share</h3>
             <p>Work with your team and share strategies instantly.</p>
           </div>
           <div className="p-4">
-            <h3 className="text-xl font-semibold mb-2 text-[#7AC142]">Win Games</h3>
+            <h3 className="text-xl font-semibold mb-2 text-gray-200">Win Games</h3>
             <p>Execute your plays on the field and dominate the game.</p>
           </div>
         </div>
       </section>
 
       {/* Footer */}
-      <footer className="bg-gray-800 text-[#B2B7BB] text-center py-4 mt-auto">
+      <footer className="bg-gray-800/80 text-gray-400 text-center py-4 mt-auto">
         &copy; 2024 HuddlUp
       </footer>
     </div>

--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -623,7 +623,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
             {selectedRouteIndex !== null ? (
               <>
                 <button
-                  className="flex items-center bg-red-600 hover:bg-red-500 px-2 py-1 rounded mb-2"
+                  className="flex items-center btn-dark px-2 py-1 mb-2"
                   onClick={handleDeleteRoute}
                 >
                   <Trash2 className="w-4 h-4 mr-1" /> Delete Route
@@ -812,13 +812,13 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
             />
             <button
               onClick={handleSave}
-              className="w-full bg-green-600 hover:bg-green-500 px-4 py-2 rounded text-white"
+              className="w-full btn-dark px-4 py-2"
             >
               Save Play
             </button>
             <button
               onClick={handleSaveAs}
-              className="w-full mt-2 bg-blue-600 hover:bg-blue-500 px-4 py-2 rounded text-white"
+              className="w-full mt-2 btn-dark px-4 py-2"
             >
               Save As
             </button>
@@ -856,7 +856,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
               </button>
               <button
                 onClick={handleSaveAsConfirm}
-                className="px-3 py-1 rounded bg-blue-600 text-white"
+                className="px-3 py-1 btn-dark"
               >
                 Save
               </button>
@@ -872,7 +872,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
             <p>Your play has been saved successfully.</p>
             <button
               onClick={() => setShowSaveModal(false)}
-              className="mt-2 bg-blue-600 hover:bg-blue-500 text-white px-3 py-1 rounded"
+              className="mt-2 btn-dark px-3 py-1"
             >
               OK
             </button>
@@ -881,13 +881,13 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
       )}
 
       {saveError && (
-        <div className="fixed top-4 right-4 bg-red-600 text-white px-4 py-2 rounded shadow-md">
+        <div className="fixed top-4 right-4 bg-gray-700 text-white px-4 py-2 rounded shadow-md">
           {saveError}
         </div>
       )}
 
       {showToast && (
-        <div className="fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow-md">
+        <div className="fixed top-4 right-4 bg-gray-700 text-white px-4 py-2 rounded shadow-md">
           Play saved!
         </div>
       )}

--- a/src/components/AddToPlaybookModal.jsx
+++ b/src/components/AddToPlaybookModal.jsx
@@ -113,7 +113,7 @@ const AddToPlaybookModal = ({ playId, onClose }) => {
           </button>
           <button
             onClick={handleAdd}
-            className="px-3 py-1 rounded bg-blue-600 text-white"
+            className="px-3 py-1 btn-dark"
           >
             Add
           </button>

--- a/src/components/PlayLibrary.jsx
+++ b/src/components/PlayLibrary.jsx
@@ -78,7 +78,7 @@ const PlayLibrary = ({ onSelectPlay, user, openSignIn }) => {
             onClick={() => onSelectPlay(play)}
           >
             <button
-              className="absolute top-1 right-1 bg-blue-600 text-white text-xs px-2 py-1 rounded"
+              className="absolute top-1 right-1 btn-dark text-xs px-2 py-1"
               onClick={(e) => {
                 e.stopPropagation();
                 setSelectedPlayId(play.id);
@@ -119,7 +119,7 @@ const PlayLibrary = ({ onSelectPlay, user, openSignIn }) => {
         />
       )}
       {showConfirmation && (
-        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-green-600 text-white px-4 py-2 rounded shadow">
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-gray-700 text-white px-4 py-2 rounded shadow">
           Play successfully added to playbook
         </div>
       )}

--- a/src/components/PlaybookLibrary.jsx
+++ b/src/components/PlaybookLibrary.jsx
@@ -325,7 +325,7 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
               </button>
               <button
                 onClick={() => deletePlaybook(book.id)}
-                className="bg-red-600 hover:bg-red-500 px-2 py-1 rounded text-sm"
+                className="btn-dark px-2 py-1 text-sm"
               >
                 <Trash2 className="w-4 h-4" />
               </button>

--- a/src/components/PrintOptionsModal.jsx
+++ b/src/components/PrintOptionsModal.jsx
@@ -137,7 +137,7 @@ const PrintOptionsModal = ({ onClose, onPrint }) => {
           <button onClick={onClose} className="px-3 py-1 rounded bg-gray-300">
             Cancel
           </button>
-          <button onClick={handleSubmit} className="px-3 py-1 rounded bg-blue-600 text-white">
+          <button onClick={handleSubmit} className="px-3 py-1 btn-dark">
             Print
           </button>
         </div>

--- a/src/components/SignIn.jsx
+++ b/src/components/SignIn.jsx
@@ -43,13 +43,13 @@ const SignIn = () => {
           className="p-2 rounded text-black"
           required
         />
-        <button type="submit" className="bg-blue-600 text-white px-3 py-2 rounded">
+        <button type="submit" className="btn-dark px-3 py-2">
           {isRegister ? 'Create Account' : 'Sign In'}
         </button>
       </form>
       <button
         onClick={() => setIsRegister(!isRegister)}
-        className="text-sm text-blue-300 mt-2"
+        className="text-sm text-gray-300 mt-2"
       >
         {isRegister ? 'Already have an account?' : 'Need an account?'}
       </button>

--- a/src/components/SignInModal.jsx
+++ b/src/components/SignInModal.jsx
@@ -60,14 +60,14 @@ const SignInModal = ({ onClose }) => {
           />
           <button
             type="submit"
-            className="mt-2 px-3 py-1 rounded bg-blue-600 hover:bg-blue-500"
+            className="mt-2 px-3 py-1 btn-dark"
           >
             {isRegister ? 'Create Account' : 'Sign In'}
           </button>
         </form>
         <button
           onClick={() => setIsRegister(!isRegister)}
-          className="text-sm text-blue-300 mt-2"
+          className="text-sm text-gray-300 mt-2"
         >
           {isRegister ? 'Already have an account?' : 'Need an account?'}
         </button>

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -21,13 +21,13 @@ const Toolbar = ({ onNewPlay, onUndo, onExport, onShare }) => {
   return (
     <div className="flex flex-wrap gap-2">
       <button
-        className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+        className="flex items-center btn-dark"
         onClick={onNewPlay}
       >
         <PlusCircle className="w-4 h-4 mr-1" /> New Play
       </button>
       <button
-        className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+        className="flex items-center btn-dark"
         onClick={onUndo}
       >
         <RotateCcw className="w-4 h-4 mr-1" /> Undo
@@ -36,21 +36,21 @@ const Toolbar = ({ onNewPlay, onUndo, onExport, onShare }) => {
         <select
           value={aspect}
           onChange={(e) => setAspect(e.target.value)}
-          className="bg-gray-700 text-white p-1 rounded"
+          className="bg-gray-700/80 text-gray-100 p-1 rounded"
         >
           <option value="2">2.25 x 1.125</option>
           <option value="1.333">1.5 x 1.125</option>
           <option value="1">1.125 x 1.125</option>
         </select>
         <button
-          className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+          className="flex items-center btn-dark"
           onClick={handleExportClick}
         >
           <Download className="w-4 h-4 mr-1" /> Export
         </button>
       </div>
       <button
-        className="flex items-center bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded"
+        className="flex items-center btn-dark"
 
         onClick={handleShareClick}
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,9 @@
 @import "tailwindcss";
+
+body {
+  @apply min-h-screen bg-gradient-to-b from-[#333333] to-[#111111] text-gray-100;
+}
+
 .hero {
   background-color: #000;
   background-image: repeating-linear-gradient(
@@ -9,4 +14,8 @@
     transparent 10px
   );
   background-size: 20px 20px;
+}
+
+.btn-dark {
+  @apply bg-gray-700/80 hover:bg-gray-600/80 text-gray-100 px-3 py-1 rounded transition shadow-sm hover:shadow-lg;
 }


### PR DESCRIPTION
## Summary
- style pages with charcoal gradient background and light text
- add `.btn-dark` utility for consistent dark buttons with hover shadows
- refactor main layout, nav bar, and various components to use new color scheme
- remove old bright colors from buttons and messages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68432fb3d1348324bdfb8532e77deaf1