### PR TITLE
Fix Save As saved state

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -236,7 +236,6 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
         playData,
       );
       setPlayName(newName);
-      setSavedState(getCurrentState());
       setShowSaveAsModal(false);
       setShowSaveModal(true);
       setShowToast(true);


### PR DESCRIPTION
## Summary
- update handleSaveAsConfirm to avoid using outdated play name when updating savedState

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684339015b8083249fdf8f4349b08b60