### PR TITLE
Fix sign-in handler dependencies

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link, useNavigate, useLocation } from 'react-router-dom';
 import { onAuthStateChanged, signOut } from 'firebase/auth';
 import { auth } from './firebase';
@@ -113,7 +113,7 @@ const App = () => {
   const [user, setUser] = useState(null);
   const [showSignInModal, setShowSignInModal] = useState(false);
 
-  const openSignIn = () => setShowSignInModal(true);
+  const openSignIn = useCallback(() => setShowSignInModal(true), []);
 
 
   useEffect(() => {

--- a/src/components/PlayLibrary.jsx
+++ b/src/components/PlayLibrary.jsx
@@ -25,7 +25,7 @@ const PlayLibrary = ({ onSelectPlay, user, openSignIn }) => {
       setPlays(arr);
     };
     fetchPlays();
-  }, [user, openSignIn]);
+  }, [user]);
 
   if (!auth.currentUser) {
     return <div className="p-4">Please sign in to view your plays.</div>;

--- a/src/components/PlaybookLibrary.jsx
+++ b/src/components/PlaybookLibrary.jsx
@@ -41,7 +41,7 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
       setPlaybooks(arr);
     };
     fetchBooks();
-  }, [user, openSignIn]);
+  }, [user]);
 
   useEffect(() => {
     if (!auth.currentUser) {
@@ -59,7 +59,7 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
       setPlaysMap(obj);
     };
     fetchPlays();
-  }, [user, openSignIn]);
+  }, [user]);
 
   if (!auth.currentUser) {
     return <div className="p-4">Please sign in to view your playbooks.</div>;


### PR DESCRIPTION
## Summary
- wrap `openSignIn` in `useCallback`
- remove `openSignIn` from effects that fetch user data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6843390084a48324860bb511449a6a4b