### PR TITLE
Add iOS fallbacks for canvas download/share

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -503,9 +503,18 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
     });
   };
 
+  const isIos = /iPad|iPhone|iPod/.test(navigator.userAgent);
+
   const handleExport = async (ratio) => {
     const url = await getExportDataUrl(ratio);
     if (!url) return;
+
+    if (isIos) {
+      // iOS Safari doesn't reliably support the download attribute
+      window.open(url, "_blank");
+      return;
+    }
+
     const link = document.createElement("a");
     link.href = url;
     link.download = `${playName || "play"}.png`;
@@ -518,7 +527,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
     const url = await getExportDataUrl(ratio);
 
     if (!url) return;
-    if (navigator.share && navigator.canShare) {
+    if (navigator.share && navigator.canShare && !isIos) {
       const res = await fetch(url);
       const blob = await res.blob();
       const file = new File([blob], `${playName || "play"}.png`, {
@@ -531,6 +540,21 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
         console.error(e);
       }
     }
+
+    if (navigator.share && isIos) {
+      try {
+        await navigator.share({ url, title: playName || "Play" });
+        return;
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    if (isIos) {
+      window.open(url, "_blank");
+      return;
+    }
+
     const link = document.createElement("a");
     link.href = url;
     link.download = `${playName || "play"}.png`;


### PR DESCRIPTION
## Summary
- detect iOS devices in `PlayEditor`
- add fallbacks to open the exported image in a new tab if download or share isn't supported
- support sharing the URL on iOS

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6843401d2bc08324a592cbfc97d6a3d7