### PR TITLE
Improve play confirmations

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -173,7 +173,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
       const dataURL = await getExportDataUrl(4 / 3);
       const printURL = await getExportDataUrl(4 / 3, THICKNESS_MULTIPLIER);
 
-      const playKey = `Play-${Date.now()}`;
+      const playKey = `Play-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
       const playData = {
         id: playKey,
         players,
@@ -222,7 +222,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
     try {
       const dataURL = await getExportDataUrl(4 / 3);
       const printURL = await getExportDataUrl(4 / 3, THICKNESS_MULTIPLIER);
-      const playKey = `Play-${Date.now()}`;
+      const playKey = `Play-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
       const playData = {
         id: playKey,
         players,
@@ -244,20 +244,16 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
       setPlayName(newName);
       // Ensure the "Save As" modal closes before showing confirmation
       setShowSaveAsModal(false);
-      setSavedState(
-        JSON.parse(
-          JSON.stringify({
-            players,
-            routes,
-            notes,
-            name: newName,
-            tags: playTags
-              .split(',')
-              .map((tag) => tag.trim())
-              .filter((tag) => tag !== ''),
-          }),
-        ),
-      );
+      setSavedState({
+        players: JSON.parse(JSON.stringify(players)),
+        routes: JSON.parse(JSON.stringify(routes)),
+        notes: JSON.parse(JSON.stringify(notes)),
+        name: newName,
+        tags: playTags
+          .split(',')
+          .map((tag) => tag.trim())
+          .filter((tag) => tag !== ''),
+      });
       // Refresh state to ensure UI updates correctly
       setPlayers([...players]);
       setRoutes([...routes]);
@@ -909,7 +905,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
       {showSaveModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
           <div className="bg-white text-black rounded p-4">
-            <h2 className="text-lg font-bold mb-2">Play Saved!</h2>
+            <h2 className="text-lg font-bold mb-2">Play saved successfully!</h2>
             <p>Your play has been saved successfully.</p>
             <button
               onClick={() => setShowSaveModal(false)}
@@ -929,7 +925,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
 
       {showToast && (
         <div className="fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow-md">
-          Play saved!
+          Play saved successfully!
         </div>
       )}
     </div>

--- a/src/components/PlayLibrary.jsx
+++ b/src/components/PlayLibrary.jsx
@@ -120,7 +120,7 @@ const PlayLibrary = ({ onSelectPlay, user, openSignIn }) => {
       )}
       {showConfirmation && (
         <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-green-600 text-white px-4 py-2 rounded shadow">
-          Play successfully added to playbook
+          Play successfully added to Playbook!
         </div>
       )}
     </div>

--- a/src/components/PlaybookLibrary.jsx
+++ b/src/components/PlaybookLibrary.jsx
@@ -11,6 +11,7 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
   const [showPrintModal, setShowPrintModal] = useState(false);
   const [printBookId, setPrintBookId] = useState(null);
   const [playsMap, setPlaysMap] = useState({});
+  const [deleteId, setDeleteId] = useState(null);
 
   useEffect(() => {
     const fetchBooks = async () => {
@@ -101,7 +102,6 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
   };
 
   const deletePlaybook = async (id) => {
-    if (!window.confirm('Delete this playbook?')) return;
     if (auth.currentUser) {
       await deleteDoc(doc(db, 'users', auth.currentUser.uid, 'playbooks', id));
     } else {
@@ -128,6 +128,12 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
 
   const toggleCollapse = (id) => {
     setCollapsed(prev => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteId) return;
+    await deletePlaybook(deleteId);
+    setDeleteId(null);
   };
 
   const handlePrint = (bookId) => {
@@ -324,7 +330,7 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
                 Print
               </button>
               <button
-                onClick={() => deletePlaybook(book.id)}
+                onClick={() => setDeleteId(book.id)}
                 className="bg-red-600 hover:bg-red-500 px-2 py-1 rounded text-sm"
               >
                 <Trash2 className="w-4 h-4" />
@@ -375,6 +381,28 @@ const PlaybookLibrary = ({ user, openSignIn }) => {
       ))}
       {showPrintModal && (
         <PrintOptionsModal onClose={() => setShowPrintModal(false)} onPrint={handlePrintConfirm} />
+      )}
+      {deleteId && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white text-black rounded p-4 w-full max-w-sm">
+            <h2 className="text-lg font-bold mb-2">Delete Playbook</h2>
+            <p>Are you sure you want to delete this playbook?</p>
+            <div className="flex justify-end gap-2 mt-4">
+              <button
+                onClick={() => setDeleteId(null)}
+                className="px-3 py-1 rounded bg-gray-300"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={confirmDelete}
+                className="px-3 py-1 rounded bg-red-600 text-white"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- confirm adding a play to a playbook with toast
- show proper save messages in Play Editor and ensure unique IDs
- use modal instead of `window.confirm` for deleting playbooks

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6843497d93c88324acfa91ea5a59459f