### PR TITLE
refactor: extract components from PlayEditor and FootballField

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -3,6 +3,9 @@ import { auth, db } from "./firebase";
 import { doc, setDoc } from "firebase/firestore";
 import FootballField from "./components/FootballField";
 import Toolbar from "./components/Toolbar";
+import SaveAsModal from "./components/SaveAsModal";
+import SaveModal from "./components/SaveModal";
+import Toast from "./components/Toast";
 import { User, ArrowRight, Trash2, StickyNote } from "lucide-react";
 import huddlupLogo from "./assets/huddlup_logo_2.svg";
 import { THICKNESS_MULTIPLIER } from "./components/PrintOptionsModal";
@@ -875,47 +878,15 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
       </div>
 
       {showSaveAsModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white text-black rounded p-4 w-full max-w-sm">
-            <h2 className="text-lg font-bold mb-2">Save Play As</h2>
-            <input
-              type="text"
-              value={saveAsName}
-              onChange={(e) => setSaveAsName(e.target.value)}
-              className="w-full p-1 rounded border mb-2"
-            />
-            <div className="flex justify-end gap-2">
-              <button
-                onClick={() => setShowSaveAsModal(false)}
-                className="px-3 py-1 rounded bg-gray-300"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleSaveAsConfirm}
-                className="px-3 py-1 rounded bg-blue-600 text-white"
-              >
-                Save
-              </button>
-            </div>
-          </div>
-        </div>
+        <SaveAsModal
+          value={saveAsName}
+          onChange={setSaveAsName}
+          onCancel={() => setShowSaveAsModal(false)}
+          onSave={handleSaveAsConfirm}
+        />
       )}
 
-      {showSaveModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white text-black rounded p-4">
-            <h2 className="text-lg font-bold mb-2">Play saved successfully!</h2>
-            <p>Your play has been saved successfully.</p>
-            <button
-              onClick={() => setShowSaveModal(false)}
-              className="mt-2 bg-blue-600 hover:bg-blue-500 text-white px-3 py-1 rounded"
-            >
-              OK
-            </button>
-          </div>
-        </div>
-      )}
+      {showSaveModal && <SaveModal onClose={() => setShowSaveModal(false)} />}
 
       {saveError && (
         <div className="fixed top-4 right-4 bg-red-600 text-white px-4 py-2 rounded shadow-md">
@@ -923,11 +894,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
         </div>
       )}
 
-      {showToast && (
-        <div className="fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow-md">
-          Play saved successfully!
-        </div>
-      )}
+      {showToast && <Toast message="Play saved successfully!" />}
     </div>
   );
 };

--- a/src/components/FootballField.jsx
+++ b/src/components/FootballField.jsx
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useState } from 'react';
+import useDefensePositions from '../hooks/useDefensePositions';
 import Konva from 'konva';
 import {
   Stage,
@@ -65,42 +66,7 @@ const FootballField = ({
   const lineOfScrimmageY = height - 250;
   const yardLineSpacing = 55;
 
-  const defenseDefaults = {
-    '1-3-1': [
-      { x: 400, y: 80 },
-      { x: 200, y: 170 },
-      { x: 400, y: 170 },
-      { x: 600, y: 170 },
-      { x: 400, y: 260 },
-    ],
-    '3-2': [
-      { x: 266.67, y: 170 },
-      { x: 533.33, y: 170 },
-      { x: 200, y: 260 },
-      { x: 400, y: 260 },
-      { x: 600, y: 260 },
-    ],
-    '4-1': [
-      { x: 400, y: 170 },
-      { x: 160, y: 260 },
-      { x: 320, y: 260 },
-      { x: 480, y: 260 },
-      { x: 640, y: 260 },
-    ],
-    '2-3': [
-      { x: 200, y: 170 },
-      { x: 400, y: 170 },
-      { x: 600, y: 170 },
-      { x: 266.67, y: 260 },
-      { x: 533.33, y: 260 },
-    ],
-  };
-
-  const getDefensePositions = (formation) => {
-    if (!formation || formation === 'No') return [];
-    const defaults = defenseDefaults[formation];
-    return defaults ? defaults.map((p) => ({ ...p })) : [];
-  };
+  const defensePositions = useDefensePositions(defenseFormation);
 
   const localStageRef = useRef(null);
   const containerRef = useRef(null);
@@ -184,7 +150,6 @@ const FootballField = ({
     return { x: newX, y: newY };
   };
 
-  const defensePositions = getDefensePositions(defenseFormation);
 
   const handleDragEnd = (e, index) => {
     const updatedPlayers = [...players];

--- a/src/components/SaveAsModal.jsx
+++ b/src/components/SaveAsModal.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const SaveAsModal = ({ value, onChange, onCancel, onSave }) => (
+  <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+    <div className="bg-white text-black rounded p-4 w-full max-w-sm">
+      <h2 className="text-lg font-bold mb-2">Save Play As</h2>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full p-1 rounded border mb-2"
+      />
+      <div className="flex justify-end gap-2">
+        <button onClick={onCancel} className="px-3 py-1 rounded bg-gray-300">
+          Cancel
+        </button>
+        <button onClick={onSave} className="px-3 py-1 rounded bg-blue-600 text-white">
+          Save
+        </button>
+      </div>
+    </div>
+  </div>
+);
+
+export default SaveAsModal;

--- a/src/components/SaveAsModal.test.jsx
+++ b/src/components/SaveAsModal.test.jsx
@@ -1,0 +1,22 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import SaveAsModal from './SaveAsModal';
+
+test('SaveAsModal calls callbacks', () => {
+  const onChange = jest.fn();
+  const onCancel = jest.fn();
+  const onSave = jest.fn();
+
+  render(
+    <SaveAsModal value="Test" onChange={onChange} onCancel={onCancel} onSave={onSave} />
+  );
+
+  const input = screen.getByDisplayValue('Test');
+  fireEvent.change(input, { target: { value: 'New' } });
+  expect(onChange).toHaveBeenCalledWith('New');
+
+  fireEvent.click(screen.getByText('Cancel'));
+  expect(onCancel).toHaveBeenCalled();
+
+  fireEvent.click(screen.getByText('Save'));
+  expect(onSave).toHaveBeenCalled();
+});

--- a/src/components/SaveModal.jsx
+++ b/src/components/SaveModal.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const SaveModal = ({ onClose }) => (
+  <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+    <div className="bg-white text-black rounded p-4">
+      <h2 className="text-lg font-bold mb-2">Play saved successfully!</h2>
+      <p>Your play has been saved successfully.</p>
+      <button
+        onClick={onClose}
+        className="mt-2 bg-blue-600 hover:bg-blue-500 text-white px-3 py-1 rounded"
+      >
+        OK
+      </button>
+    </div>
+  </div>
+);
+
+export default SaveModal;

--- a/src/components/SaveModal.test.jsx
+++ b/src/components/SaveModal.test.jsx
@@ -1,0 +1,9 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import SaveModal from './SaveModal';
+
+test('SaveModal calls onClose', () => {
+  const onClose = jest.fn();
+  render(<SaveModal onClose={onClose} />);
+  fireEvent.click(screen.getByText('OK'));
+  expect(onClose).toHaveBeenCalled();
+});

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Toast = ({ message }) => (
+  <div className="fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow-md">
+    {message}
+  </div>
+);
+
+export default Toast;

--- a/src/hooks/useDefensePositions.js
+++ b/src/hooks/useDefensePositions.js
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+
+const defenseDefaults = {
+  '1-3-1': [
+    { x: 400, y: 80 },
+    { x: 200, y: 170 },
+    { x: 400, y: 170 },
+    { x: 600, y: 170 },
+    { x: 400, y: 260 },
+  ],
+  '3-2': [
+    { x: 266.67, y: 170 },
+    { x: 533.33, y: 170 },
+    { x: 200, y: 260 },
+    { x: 400, y: 260 },
+    { x: 600, y: 260 },
+  ],
+  '4-1': [
+    { x: 400, y: 170 },
+    { x: 160, y: 260 },
+    { x: 320, y: 260 },
+    { x: 480, y: 260 },
+    { x: 640, y: 260 },
+  ],
+  '2-3': [
+    { x: 200, y: 170 },
+    { x: 400, y: 170 },
+    { x: 600, y: 170 },
+    { x: 266.67, y: 260 },
+    { x: 533.33, y: 260 },
+  ],
+};
+
+export default function useDefensePositions(formation) {
+  return useMemo(() => {
+    if (!formation || formation === 'No') return [];
+    const defaults = defenseDefaults[formation];
+    return defaults ? defaults.map((p) => ({ ...p })) : [];
+  }, [formation]);
+}

--- a/src/hooks/useDefensePositions.test.js
+++ b/src/hooks/useDefensePositions.test.js
@@ -1,0 +1,15 @@
+import { renderHook } from '@testing-library/react';
+import useDefensePositions from './useDefensePositions';
+
+describe('useDefensePositions', () => {
+  test('returns empty array when formation is "No"', () => {
+    const { result } = renderHook(() => useDefensePositions('No'));
+    expect(result.current).toEqual([]);
+  });
+
+  test('returns defaults for 3-2 formation', () => {
+    const { result } = renderHook(() => useDefensePositions('3-2'));
+    expect(result.current).toHaveLength(5);
+    expect(result.current[0]).toEqual({ x: 266.67, y: 170 });
+  });
+});


### PR DESCRIPTION
## Summary
- extract small modal and toast components
- pull defense position logic into a hook
- use new components in PlayEditor and FootballField
- add unit tests for new hook and components

## Testing
- `npx jest --runInBand` *(fails: npm 403)*

------
https://chatgpt.com/codex/tasks/task_e_684399216d908324b1ffd63370bfe1b1