### PR TITLE
Improve save status tracking

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -95,6 +95,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
   const [saveError, setSaveError] = useState(null);
   const [saveAsName, setSaveAsName] = useState('');
   const [savedState, setSavedState] = useState(null);
+  const [isSaved, setIsSaved] = useState(false);
   const [defenseFormation, setDefenseFormation] = useState('No');
   const stageRef = useRef(null);
 
@@ -135,6 +136,18 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
       return () => clearTimeout(timer);
     }
   }, [saveError]);
+
+  // Keep track of whether the current state matches the last saved snapshot
+  useEffect(() => {
+    if (!savedState) {
+      setIsSaved(false);
+      return;
+    }
+    const current = getCurrentState();
+    setIsSaved(
+      JSON.stringify(current) === JSON.stringify(savedState),
+    );
+  }, [players, routes, notes, playName, playTags, savedState]);
 
   const handleNewPlay = () => {
     setUndoStack((prev) => [
@@ -567,12 +580,7 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
     document.body.removeChild(link);
   };
 
-  const isPlaySaved = () => {
-    if (!savedState) return false;
-    return (
-      JSON.stringify(getCurrentState()) === JSON.stringify(savedState)
-    );
-  };
+  const isPlaySaved = () => isSaved;
 
   return (
     <div className="flex flex-col bg-gray-900 text-white min-h-screen">

--- a/src/components/SaveModal.jsx
+++ b/src/components/SaveModal.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 const SaveModal = ({ onClose }) => (
   <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
     <div className="bg-white text-black rounded p-4">
-      <h2 className="text-lg font-bold mb-2">Play saved successfully!</h2>
-      <p>Your play has been saved successfully.</p>
+      <h2 className="text-lg font-bold mb-2">Your play was saved</h2>
+      <p>Your play was saved.</p>
       <button
         onClick={onClose}
         className="mt-2 bg-blue-600 hover:bg-blue-500 text-white px-3 py-1 rounded"


### PR DESCRIPTION
## Summary
- add `isSaved` state
- recompute saved status whenever editor state changes
- confirm popup says "Your play was saved"

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a8ceb1a0832486e48cd5eeeacfef