### PR TITLE
Use portal for SaveModal and Toast

### DIFF
--- a/src/PlayEditor.jsx
+++ b/src/PlayEditor.jsx
@@ -6,6 +6,7 @@ import Toolbar from "./components/Toolbar";
 import SaveAsModal from "./components/SaveAsModal";
 import SaveModal from "./components/SaveModal";
 import Toast from "./components/Toast";
+import ModalPortal from "./components/ModalPortal";
 import { User, ArrowRight, Trash2, StickyNote } from "lucide-react";
 import huddlupLogo from "./assets/huddlup_logo_2.svg";
 import { THICKNESS_MULTIPLIER } from "./components/PrintOptionsModal";
@@ -922,7 +923,11 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
         />
       )}
 
-      {showSaveModal && <SaveModal onClose={() => setShowSaveModal(false)} />}
+      {showSaveModal && (
+        <ModalPortal>
+          <SaveModal onClose={() => setShowSaveModal(false)} />
+        </ModalPortal>
+      )}
 
       {saveError && (
         <div className="fixed top-4 right-4 bg-red-600 text-white px-4 py-2 rounded shadow-md">
@@ -930,7 +935,11 @@ const PlayEditor = ({ loadedPlay, openSignIn }) => {
         </div>
       )}
 
-      {showToast && <Toast message="Play saved to library!" />}
+      {showToast && (
+        <ModalPortal>
+          <Toast message="Play saved to library!" />
+        </ModalPortal>
+      )}
     </div>
   );
 };

--- a/src/components/ModalPortal.jsx
+++ b/src/components/ModalPortal.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+const ModalPortal = ({ children }) => ReactDOM.createPortal(children, document.body);
+
+export default ModalPortal;


### PR DESCRIPTION
## Summary
- add `ModalPortal` component for rendering overlays at `document.body`
- wrap `SaveModal` and `Toast` using the portal in `PlayEditor`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6843c2f86fe48324a401da023041c64b