### PR TITLE
Fix tailwind plugin key in PostCSS config

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- update postcss config to use `tailwindcss` plugin key

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843c33169d08324b16ed6e07feb2ee8